### PR TITLE
Add ESP32 EVSE external component

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,103 @@
-# esp32evse-esphome
+# ESP32 EVSE External Component for ESPHome
+
+This repository provides an ESPHome external component that integrates the ESP32-based EVSE controller using its AT command interface. The component communicates over UART to expose real-time telemetry and control primitives inside ESPHome automations.
+
+## Features
+
+- UART-based polling of the EVSE's AT command set.
+- Sensors for supply voltage, charging current, delivered energy and internal temperature.
+- Text sensor for the EVSE charging state (Ready, Charging, Fault, etc.).
+- Switch, button and number entities that wrap the start/stop, reset and current-limit commands with acknowledgement handling.
+- Configurable polling interval and optional inclusion of individual entities to match the EVSE hardware capabilities.
+
+## Repository Layout
+
+```
+components/
+└── esp32_evse/
+    ├── __init__.py
+    ├── button.py
+    ├── const.py
+    ├── esp32_evse.cpp
+    ├── esp32_evse.h
+    ├── number.py
+    ├── sensor.py
+    ├── switch.py
+    └── text_sensor.py
+```
+
+## Usage
+
+1. Clone or copy this repository into your ESPHome `custom_components` directory (for example `config/custom_components/esp32_evse`).
+2. Include the external component in your ESPHome configuration and configure the UART port connected to the EVSE controller.
+3. Enable the sensors and actuators that match your hardware. Disabled platforms are not created, so you can keep your dashboard tidy.
+
+### Example ESPHome Configuration
+
+```yaml
+external_components:
+  - source: github://your-user/esp32evse-esphome
+
+uart:
+  id: evse_uart
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+  baud_rate: 115200
+  stop_bits: 1
+  parity: NONE
+
+esp32_evse:
+  id: evse
+  uart_id: evse_uart
+  update_interval: 10s
+  sensors:
+    voltage:
+      name: EVSE Line Voltage
+    current:
+      name: EVSE Charging Current
+    energy:
+      name: EVSE Delivered Energy
+    temperature:
+      name: EVSE Controller Temperature
+  text_sensors:
+    charging_state:
+      name: EVSE Charging State
+  switches:
+    charging:
+      name: EVSE Charging Enable
+  buttons:
+    reset:
+      name: EVSE Reset
+  numbers:
+    current_limit:
+      name: EVSE Current Limit
+      min_value: 6
+      max_value: 32
+      step: 1
+```
+
+## AT Command Coverage
+
+The component issues the following EVSE AT commands during normal operation:
+
+| Command | Purpose |
+| ------- | ------- |
+| `AT` | Presence check during setup. |
+| `AT+STATE?` | Updates the charging state text sensor. |
+| `AT+VOLT?` | Provides the line voltage sensor value. |
+| `AT+CURR?` | Provides the charging current sensor value. |
+| `AT+ENER?` | Provides the delivered energy sensor value. |
+| `AT+TEMP?` | Provides the controller temperature sensor value. |
+| `AT+START` / `AT+STOP` | Toggles charging through the switch entity. |
+| `AT+SETCUR=<value>` | Adjusts the allowable charging current via the number entity. |
+| `AT+RESET` | Invoked by the reset button to restart the EVSE controller. |
+
+Responses are parsed into native ESPHome entities with retries and timeouts. Any `ERR` responses are logged so you can diagnose problems from the ESPHome logs. If your EVSE exposes additional commands you can extend the component by following the existing sensor and actuator patterns.
+
+## Notes
+
+- The component automatically retries failed commands twice before reporting an error.
+- Unknown or malformed responses are logged and ignored to keep the ESPHome runtime stable.
+- When the EVSE reports a charging state of `Charging`, `Active` or `Preparing`, the charging switch is kept in sync with the reported state.
+- For best results ensure the EVSE uses matching UART settings (baud rate, parity, stop bits) to the ESPHome configuration.
+

--- a/components/esp32_evse/__init__.py
+++ b/components/esp32_evse/__init__.py
@@ -1,0 +1,57 @@
+"""Code generation helpers for the ESP32 EVSE external component."""
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import uart
+from esphome.const import CONF_ID, CONF_UPDATE_INTERVAL
+
+from . import sensor as sensor_config
+from . import text_sensor as text_sensor_config
+from . import switch as switch_config
+from . import button as button_config
+from . import number as number_config
+from .const import (
+    CONF_BUTTONS,
+    CONF_NUMBERS,
+    CONF_SENSORS,
+    CONF_SWITCHES,
+    CONF_TEXT_SENSORS,
+    DEFAULT_UPDATE_INTERVAL,
+)
+
+AUTO_LOAD = ["sensor", "text_sensor", "number", "switch", "button"]
+DEPENDENCIES = ["uart"]
+
+esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
+ESP32EVSEComponent = esp32_evse_ns.class_(
+    "ESP32EVSEComponent", cg.PollingComponent, uart.UARTDevice
+)
+
+CONFIG_SCHEMA = (
+    cv.Schema({cv.GenerateID(): cv.declare_id(ESP32EVSEComponent)})
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(
+        {
+            cv.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL): cv.update_interval,
+            cv.Optional(CONF_SENSORS, default={}): sensor_config.SENSORS_SCHEMA,
+            cv.Optional(CONF_TEXT_SENSORS, default={}): text_sensor_config.TEXT_SENSORS_SCHEMA,
+            cv.Optional(CONF_SWITCHES, default={}): switch_config.SWITCHES_SCHEMA,
+            cv.Optional(CONF_BUTTONS, default={}): button_config.BUTTONS_SCHEMA,
+            cv.Optional(CONF_NUMBERS, default={}): number_config.NUMBERS_SCHEMA,
+        }
+    )
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)
+
+    cg.add(var.set_update_interval(config[CONF_UPDATE_INTERVAL]))
+
+    await sensor_config.setup_sensors(var, config.get(CONF_SENSORS))
+    await text_sensor_config.setup_text_sensors(var, config.get(CONF_TEXT_SENSORS))
+    await switch_config.setup_switches(var, config.get(CONF_SWITCHES))
+    await button_config.setup_buttons(var, config.get(CONF_BUTTONS))
+    await number_config.setup_numbers(var, config.get(CONF_NUMBERS))

--- a/components/esp32_evse/button.py
+++ b/components/esp32_evse/button.py
@@ -1,0 +1,34 @@
+"""Button platform for the ESP32 EVSE external component."""
+
+from __future__ import annotations
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import button
+from esphome.const import ICON_RESTART
+
+from .const import CONF_RESET_BUTTON
+
+esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
+ESP32EVSEComponent = esp32_evse_ns.class_("ESP32EVSEComponent")
+ESP32EVSEResetButton = esp32_evse_ns.class_(
+    "ESP32EVSEResetButton", button.Button, cg.Parented(ESP32EVSEComponent)
+)
+
+BUTTONS_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_RESET_BUTTON): button.button_schema(
+            ESP32EVSEResetButton, icon=ICON_RESTART
+        )
+    }
+)
+
+
+async def setup_buttons(var: cg.Pvariable, config: dict | None) -> None:
+    if not config:
+        return
+
+    if CONF_RESET_BUTTON in config:
+        btn = await button.new_button(config[CONF_RESET_BUTTON])
+        cg.add(var.set_reset_button(btn))
+

--- a/components/esp32_evse/const.py
+++ b/components/esp32_evse/const.py
@@ -1,0 +1,38 @@
+"""Shared constants for the ESP32 EVSE external component."""
+
+from esphome.const import (
+    CONF_CURRENT,
+    CONF_ENERGY,
+    CONF_ID,
+    CONF_TEMPERATURE,
+    CONF_UPDATE_INTERVAL,
+    CONF_VOLTAGE,
+)
+
+CONF_CHARGING_STATE = "charging_state"
+CONF_CHARGING_SWITCH = "charging"
+CONF_RESET_BUTTON = "reset"
+CONF_CURRENT_LIMIT = "current_limit"
+
+DEFAULT_UPDATE_INTERVAL = "15s"
+# Mapping between configuration keys and the EVSE AT query commands.
+SENSOR_QUERIES = {
+    CONF_CHARGING_STATE: "AT+STATE?",
+    CONF_VOLTAGE: "AT+VOLT?",
+    CONF_CURRENT: "AT+CURR?",
+    CONF_ENERGY: "AT+ENER?",
+    CONF_TEMPERATURE: "AT+TEMP?",
+}
+
+# Mapping between configuration keys and EVSE control commands.
+COMMAND_START_CHARGING = "AT+START"
+COMMAND_STOP_CHARGING = "AT+STOP"
+COMMAND_RESET = "AT+RESET"
+COMMAND_SET_CURRENT_LIMIT = "AT+SETCUR"
+
+CONF_SENSORS = "sensors"
+CONF_TEXT_SENSORS = "text_sensors"
+CONF_SWITCHES = "switches"
+CONF_BUTTONS = "buttons"
+CONF_NUMBERS = "numbers"
+

--- a/components/esp32_evse/esp32_evse.cpp
+++ b/components/esp32_evse/esp32_evse.cpp
@@ -1,0 +1,336 @@
+#include "esp32_evse.h"
+
+#include "esphome/core/helpers.h"
+
+#include <cmath>
+
+namespace esphome {
+namespace esp32_evse {
+
+static const char *const TAG = "esp32_evse";
+
+ESP32EVSEComponent::ESP32EVSEComponent() : PollingComponent(15000) {}
+
+void ESP32EVSEComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up ESP32 EVSE interface...");
+  this->flush_input_();
+
+  std::string response;
+  if (this->execute_command_("AT", &response)) {
+    if (!response.empty() && response != "OK") {
+      ESP_LOGI(TAG, "EVSE replied: %s", response.c_str());
+    }
+  } else {
+    ESP_LOGW(TAG, "No response to basic AT probe. Continuing anyway.");
+  }
+}
+
+void ESP32EVSEComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "ESP32 EVSE external component");
+  LOG_SENSOR("  ", "Voltage", this->voltage_sensor_);
+  LOG_SENSOR("  ", "Current", this->current_sensor_);
+  LOG_SENSOR("  ", "Energy", this->energy_sensor_);
+  LOG_SENSOR("  ", "Temperature", this->temperature_sensor_);
+  LOG_TEXT_SENSOR("  ", "Charging State", this->charging_state_text_sensor_);
+  LOG_SWITCH("  ", "Charging Control", this->charging_switch_);
+  LOG_BUTTON("  ", "Reset", this->reset_button_);
+  LOG_NUMBER("  ", "Current Limit", this->current_limit_number_);
+  LOG_UPDATE_INTERVAL(this);
+}
+
+void ESP32EVSEComponent::loop() {
+  while (this->available()) {
+    const char c = this->read();
+    if (c == '\r') {
+      continue;
+    }
+    if (c == '\n') {
+      if (!this->incoming_line_.empty()) {
+        ESP_LOGD(TAG, "Unsolicited response: %s", this->incoming_line_.c_str());
+        this->incoming_line_.clear();
+      }
+      continue;
+    }
+    this->incoming_line_.push_back(c);
+  }
+}
+
+void ESP32EVSEComponent::update() {
+  this->update_charging_state_();
+  this->update_voltage_();
+  this->update_current_();
+  this->update_energy_();
+  this->update_temperature_();
+}
+
+bool ESP32EVSEComponent::set_charging_enabled(bool enabled) {
+  const std::string command = enabled ? "AT+START" : "AT+STOP";
+  if (!this->execute_command_(command)) {
+    return false;
+  }
+  this->last_charging_enabled_ = enabled;
+  if (this->charging_switch_ != nullptr) {
+    this->charging_switch_->publish_state(enabled);
+  }
+  return true;
+}
+
+bool ESP32EVSEComponent::reset_evse() {
+  if (!this->execute_command_("AT+RESET")) {
+    return false;
+  }
+  return true;
+}
+
+bool ESP32EVSEComponent::set_current_limit(float value) {
+  char buffer[16];
+  snprintf(buffer, sizeof(buffer), "%.1f", value);
+  std::string command = "AT+SETCUR=";
+  command += buffer;
+  if (!this->execute_command_(command)) {
+    return false;
+  }
+  if (this->current_limit_number_ != nullptr) {
+    this->current_limit_number_->publish_state(value);
+  }
+  return true;
+}
+
+bool ESP32EVSEComponent::execute_query_(const std::string &command, std::string &response) {
+  if (!this->execute_command_(command, &response)) {
+    return false;
+  }
+  if (response.empty()) {
+    ESP_LOGW(TAG, "Received empty payload for %s", command.c_str());
+    return false;
+  }
+  return true;
+}
+
+bool ESP32EVSEComponent::execute_command_(const std::string &command, std::string *response) {
+  for (uint8_t attempt = 0; attempt <= this->command_retries_; ++attempt) {
+    this->flush_input_();
+    this->write_str(command.c_str());
+    this->write_str("\r\n");
+    this->flush();
+
+    std::string first_line;
+    if (!this->read_line_(first_line, this->command_timeout_ms_)) {
+      ESP_LOGW(TAG, "Timeout waiting for response to %s (attempt %u)", command.c_str(),
+               static_cast<unsigned>(attempt + 1));
+      continue;
+    }
+
+    if (first_line.empty()) {
+      continue;
+    }
+
+    if (first_line == "OK") {
+      if (response != nullptr) {
+        response->clear();
+      }
+      return true;
+    }
+
+    if (first_line.rfind("ERR", 0) == 0) {
+      this->publish_error_(command.c_str(), first_line);
+      continue;
+    }
+
+    if (response != nullptr) {
+      *response = first_line;
+    }
+
+    std::string second_line;
+    if (this->read_line_(second_line, 150)) {
+      if (second_line == "OK") {
+        return true;
+      }
+      if (second_line.rfind("ERR", 0) == 0) {
+        this->publish_error_(command.c_str(), second_line);
+        continue;
+      }
+      // Preserve unparsed data for visibility in the logs.
+      ESP_LOGD(TAG, "Additional response to %s: %s", command.c_str(), second_line.c_str());
+    }
+
+    return true;
+  }
+
+  ESP_LOGE(TAG, "Failed to execute command %s after %u attempts", command.c_str(),
+           static_cast<unsigned>(this->command_retries_ + 1));
+  return false;
+}
+
+bool ESP32EVSEComponent::read_line_(std::string &line, uint32_t timeout_ms) const {
+  line.clear();
+  const uint32_t start = millis();
+  while (millis() - start < timeout_ms) {
+    if (this->available()) {
+      const char c = this->read();
+      if (c == '\r') {
+        continue;
+      }
+      if (c == '\n') {
+        if (!line.empty()) {
+          return true;
+        }
+        continue;
+      }
+      line.push_back(c);
+      continue;
+    }
+    delay(5);
+  }
+  return !line.empty();
+}
+
+void ESP32EVSEComponent::flush_input_() {
+  this->incoming_line_.clear();
+  while (this->available()) {
+    this->read();
+  }
+}
+
+bool ESP32EVSEComponent::parse_numeric_response_(const std::string &response,
+                                                 const std::string &prefix, float *value) const {
+  if (!value) {
+    return false;
+  }
+  if (response.rfind(prefix, 0) != 0) {
+    ESP_LOGW(TAG, "Unexpected response format: %s", response.c_str());
+    return false;
+  }
+  const std::string data = response.substr(prefix.length());
+  const float parsed = parse_float(data.c_str());
+  if (isnan(parsed)) {
+    ESP_LOGW(TAG, "Failed to parse numeric value from %s", response.c_str());
+    return false;
+  }
+  *value = parsed;
+  return true;
+}
+
+bool ESP32EVSEComponent::parse_state_response_(const std::string &response,
+                                               std::string *value) const {
+  if (!value) {
+    return false;
+  }
+  const auto separator = response.find(':');
+  if (separator == std::string::npos) {
+    ESP_LOGW(TAG, "Failed to parse state from %s", response.c_str());
+    return false;
+  }
+  *value = response.substr(separator + 1);
+  return true;
+}
+
+void ESP32EVSEComponent::publish_error_(const char *operation, const std::string &response) const {
+  ESP_LOGW(TAG, "%s returned error: %s", operation, response.c_str());
+}
+
+void ESP32EVSEComponent::update_charging_state_() {
+  if (this->charging_state_text_sensor_ == nullptr) {
+    return;
+  }
+  std::string response;
+  if (!this->execute_query_("AT+STATE?", response)) {
+    return;
+  }
+  std::string state;
+  if (!this->parse_state_response_(response, &state)) {
+    return;
+  }
+  this->charging_state_text_sensor_->publish_state(state);
+  const bool is_active = state == "Charging" || state == "Active" || state == "Preparing";
+  this->last_charging_enabled_ = is_active;
+  if (this->charging_switch_ != nullptr) {
+    this->charging_switch_->publish_state(this->last_charging_enabled_);
+  }
+}
+
+void ESP32EVSEComponent::update_voltage_() {
+  if (this->voltage_sensor_ == nullptr) {
+    return;
+  }
+  std::string response;
+  if (!this->execute_query_("AT+VOLT?", response)) {
+    return;
+  }
+  float value;
+  if (!this->parse_numeric_response_(response, "VOLT:", &value)) {
+    return;
+  }
+  this->voltage_sensor_->publish_state(value);
+}
+
+void ESP32EVSEComponent::update_current_() {
+  if (this->current_sensor_ == nullptr) {
+    return;
+  }
+  std::string response;
+  if (!this->execute_query_("AT+CURR?", response)) {
+    return;
+  }
+  float value;
+  if (!this->parse_numeric_response_(response, "CURR:", &value)) {
+    return;
+  }
+  this->current_sensor_->publish_state(value);
+}
+
+void ESP32EVSEComponent::update_energy_() {
+  if (this->energy_sensor_ == nullptr) {
+    return;
+  }
+  std::string response;
+  if (!this->execute_query_("AT+ENER?", response)) {
+    return;
+  }
+  float value;
+  if (!this->parse_numeric_response_(response, "ENER:", &value)) {
+    return;
+  }
+  this->energy_sensor_->publish_state(value);
+}
+
+void ESP32EVSEComponent::update_temperature_() {
+  if (this->temperature_sensor_ == nullptr) {
+    return;
+  }
+  std::string response;
+  if (!this->execute_query_("AT+TEMP?", response)) {
+    return;
+  }
+  float value;
+  if (!this->parse_numeric_response_(response, "TEMP:", &value)) {
+    return;
+  }
+  this->temperature_sensor_->publish_state(value);
+}
+
+void ESP32EVSEChargingSwitch::write_state(bool state) {
+  if (!this->parent_->set_charging_enabled(state)) {
+    this->publish_state(this->state);
+    return;
+  }
+  this->publish_state(state);
+}
+
+void ESP32EVSEResetButton::press_action() {
+  if (!this->parent_->reset_evse()) {
+    ESP_LOGW(TAG, "Reset command failed");
+  }
+}
+
+void ESP32EVSECurrentLimitNumber::control(float value) {
+  if (!this->parent_->set_current_limit(value)) {
+    this->publish_state(this->state);
+    return;
+  }
+  this->publish_state(value);
+}
+
+}  // namespace esp32_evse
+}  // namespace esphome
+

--- a/components/esp32_evse/esp32_evse.h
+++ b/components/esp32_evse/esp32_evse.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "esphome/components/button/button.h"
+#include "esphome/components/number/number.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/switch/switch.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/core/component.h"
+#include "esphome/core/log.h"
+
+#include <string>
+
+namespace esphome {
+namespace esp32_evse {
+
+class ESP32EVSEChargingSwitch;
+class ESP32EVSEResetButton;
+class ESP32EVSECurrentLimitNumber;
+
+class ESP32EVSEComponent : public PollingComponent, public uart::UARTDevice {
+ public:
+  ESP32EVSEComponent();
+
+  void set_voltage_sensor(sensor::Sensor *sensor) { voltage_sensor_ = sensor; }
+  void set_current_sensor(sensor::Sensor *sensor) { current_sensor_ = sensor; }
+  void set_energy_sensor(sensor::Sensor *sensor) { energy_sensor_ = sensor; }
+  void set_temperature_sensor(sensor::Sensor *sensor) { temperature_sensor_ = sensor; }
+  void set_charging_state_text_sensor(text_sensor::TextSensor *sensor) {
+    charging_state_text_sensor_ = sensor;
+  }
+  void set_charging_switch(ESP32EVSEChargingSwitch *sw) { charging_switch_ = sw; }
+  void set_reset_button(ESP32EVSEResetButton *button) { reset_button_ = button; }
+  void set_current_limit_number(ESP32EVSECurrentLimitNumber *number) {
+    current_limit_number_ = number;
+  }
+
+  void setup() override;
+  void dump_config() override;
+  void loop() override;
+  void update() override;
+
+  bool set_charging_enabled(bool enabled);
+  bool reset_evse();
+  bool set_current_limit(float value);
+
+ protected:
+  bool execute_query_(const std::string &command, std::string &response);
+  bool execute_command_(const std::string &command, std::string *response = nullptr);
+  bool read_line_(std::string &line, uint32_t timeout_ms) const;
+  void flush_input_();
+  bool parse_numeric_response_(const std::string &response, const std::string &prefix,
+                               float *value) const;
+  bool parse_state_response_(const std::string &response, std::string *value) const;
+
+  void publish_error_(const char *operation, const std::string &response) const;
+
+  void update_charging_state_();
+  void update_voltage_();
+  void update_current_();
+  void update_energy_();
+  void update_temperature_();
+
+  sensor::Sensor *voltage_sensor_{nullptr};
+  sensor::Sensor *current_sensor_{nullptr};
+  sensor::Sensor *energy_sensor_{nullptr};
+  sensor::Sensor *temperature_sensor_{nullptr};
+  text_sensor::TextSensor *charging_state_text_sensor_{nullptr};
+  ESP32EVSEChargingSwitch *charging_switch_{nullptr};
+  ESP32EVSEResetButton *reset_button_{nullptr};
+  ESP32EVSECurrentLimitNumber *current_limit_number_{nullptr};
+
+  std::string incoming_line_;
+  uint32_t command_timeout_ms_{1500};
+  uint8_t command_retries_{2};
+  bool last_charging_enabled_{false};
+};
+
+class ESP32EVSEChargingSwitch : public switch_::Switch, public Parented<ESP32EVSEComponent> {
+ public:
+  void write_state(bool state) override;
+};
+
+class ESP32EVSEResetButton : public button::Button, public Parented<ESP32EVSEComponent> {
+ protected:
+  void press_action() override;
+};
+
+class ESP32EVSECurrentLimitNumber : public number::Number, public Parented<ESP32EVSEComponent> {
+ protected:
+  void control(float value) override;
+};
+
+}  // namespace esp32_evse
+}  // namespace esphome
+

--- a/components/esp32_evse/number.py
+++ b/components/esp32_evse/number.py
@@ -1,0 +1,38 @@
+"""Number platform for the ESP32 EVSE external component."""
+
+from __future__ import annotations
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import number
+
+from .const import CONF_CURRENT_LIMIT
+
+esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
+ESP32EVSEComponent = esp32_evse_ns.class_("ESP32EVSEComponent")
+ESP32EVSECurrentLimitNumber = esp32_evse_ns.class_(
+    "ESP32EVSECurrentLimitNumber", number.Number, cg.Parented(ESP32EVSEComponent)
+)
+
+NUMBERS_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_CURRENT_LIMIT): number.number_schema(
+            ESP32EVSECurrentLimitNumber,
+            unit_of_measurement="A",
+            min_value=6.0,
+            max_value=32.0,
+            step=1.0,
+            mode=number.NUMBER_MODE_SLIDER,
+        )
+    }
+)
+
+
+async def setup_numbers(var: cg.Pvariable, config: dict | None) -> None:
+    if not config:
+        return
+
+    if CONF_CURRENT_LIMIT in config:
+        num = await number.new_number(config[CONF_CURRENT_LIMIT])
+        cg.add(var.set_current_limit_number(num))
+

--- a/components/esp32_evse/sensor.py
+++ b/components/esp32_evse/sensor.py
@@ -1,0 +1,64 @@
+"""Sensor definitions for the ESP32 EVSE external component."""
+
+from __future__ import annotations
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import sensor
+from esphome.const import (
+    CONF_CURRENT,
+    CONF_ENERGY,
+    CONF_TEMPERATURE,
+    CONF_VOLTAGE,
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLTAGE,
+    STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_TOTAL_INCREASING,
+    UNIT_AMPERE,
+    UNIT_CELSIUS,
+    UNIT_KILOWATT_HOURS,
+    UNIT_VOLT,
+)
+
+SENSOR_DESCRIPTIONS = {
+    CONF_VOLTAGE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_VOLT,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_VOLTAGE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_CURRENT: sensor.sensor_schema(
+        unit_of_measurement=UNIT_AMPERE,
+        accuracy_decimals=2,
+        device_class=DEVICE_CLASS_CURRENT,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+    CONF_ENERGY: sensor.sensor_schema(
+        unit_of_measurement=UNIT_KILOWATT_HOURS,
+        accuracy_decimals=3,
+        device_class=DEVICE_CLASS_ENERGY,
+        state_class=STATE_CLASS_TOTAL_INCREASING,
+    ),
+    CONF_TEMPERATURE: sensor.sensor_schema(
+        unit_of_measurement=UNIT_CELSIUS,
+        accuracy_decimals=1,
+        device_class=DEVICE_CLASS_TEMPERATURE,
+        state_class=STATE_CLASS_MEASUREMENT,
+    ),
+}
+
+SENSORS_SCHEMA = cv.Schema({cv.Optional(key): value for key, value in SENSOR_DESCRIPTIONS.items()})
+
+
+async def setup_sensors(var: cg.Pvariable, config: dict | None) -> None:
+    if not config:
+        return
+
+    for key, schema in SENSOR_DESCRIPTIONS.items():
+        if key not in config:
+            continue
+        sens = await sensor.new_sensor(config[key])
+        cg.add(getattr(var, f"set_{key}_sensor")(sens))
+

--- a/components/esp32_evse/switch.py
+++ b/components/esp32_evse/switch.py
@@ -1,0 +1,35 @@
+"""Switch platform for the ESP32 EVSE external component."""
+
+from __future__ import annotations
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import switch
+from esphome.const import ICON_FLASH
+
+from .const import CONF_CHARGING_SWITCH
+
+esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
+ESP32EVSEComponent = esp32_evse_ns.class_("ESP32EVSEComponent")
+ESP32EVSEChargingSwitch = esp32_evse_ns.class_(
+    "ESP32EVSEChargingSwitch", switch.Switch, cg.Parented(ESP32EVSEComponent)
+)
+
+SWITCHES_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_CHARGING_SWITCH): switch.switch_schema(ESP32EVSEChargingSwitch).extend(
+            {cv.Optional("icon", default=ICON_FLASH): cv.icon},
+        )
+    }
+)
+
+
+async def setup_switches(var: cg.Pvariable, config: dict | None) -> None:
+    if not config:
+        return
+
+    if CONF_CHARGING_SWITCH in config:
+        sw_config = config[CONF_CHARGING_SWITCH]
+        sw = await switch.new_switch(sw_config)
+        cg.add(var.set_charging_switch(sw))
+

--- a/components/esp32_evse/text_sensor.py
+++ b/components/esp32_evse/text_sensor.py
@@ -1,0 +1,25 @@
+"""Text sensor support for the ESP32 EVSE external component."""
+
+from __future__ import annotations
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import text_sensor
+
+from .const import CONF_CHARGING_STATE
+
+TEXT_SENSORS_SCHEMA = cv.Schema(
+    {
+        cv.Optional(CONF_CHARGING_STATE): text_sensor.text_sensor_schema(),
+    }
+)
+
+
+async def setup_text_sensors(var: cg.Pvariable, config: dict | None) -> None:
+    if not config:
+        return
+
+    if CONF_CHARGING_STATE in config:
+        sens = await text_sensor.new_text_sensor(config[CONF_CHARGING_STATE])
+        cg.add(var.set_charging_state_text_sensor(sens))
+


### PR DESCRIPTION
## Summary
- add an ESPHome external component that speaks the EVSE AT command protocol over UART
- expose telemetry sensors, charging state text sensor and control entities for start/stop, reset and current limit
- document configuration, AT command coverage and provide an example YAML configuration

## Testing
- not run (component code only)


------
https://chatgpt.com/codex/tasks/task_e_68cd8c206f888327a30c38a51ea61538