### PR TITLE
Fix platform parent registration for ESP32 EVSE component

### DIFF
--- a/components/esp32_evse/__init__.py
+++ b/components/esp32_evse/__init__.py
@@ -5,6 +5,11 @@ import esphome.config_validation as cv
 from esphome.components import uart
 from esphome.const import CONF_ID, CONF_UPDATE_INTERVAL
 
+esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
+ESP32EVSEComponent = esp32_evse_ns.class_(
+    "ESP32EVSEComponent", cg.PollingComponent, uart.UARTDevice
+)
+
 from . import sensor as sensor_config
 from . import text_sensor as text_sensor_config
 from . import switch as switch_config
@@ -21,11 +26,6 @@ from .const import (
 
 AUTO_LOAD = ["sensor", "text_sensor", "number", "switch", "button"]
 DEPENDENCIES = ["uart"]
-
-esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
-ESP32EVSEComponent = esp32_evse_ns.class_(
-    "ESP32EVSEComponent", cg.PollingComponent, uart.UARTDevice
-)
 
 CONFIG_SCHEMA = (
     cv.Schema({cv.GenerateID(): cv.declare_id(ESP32EVSEComponent)})

--- a/components/esp32_evse/button.py
+++ b/components/esp32_evse/button.py
@@ -7,12 +7,13 @@ import esphome.config_validation as cv
 from esphome.components import button
 from esphome.const import ICON_RESTART
 
+from . import ESP32EVSEComponent
 from .const import CONF_RESET_BUTTON
 
 esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
-ESP32EVSEComponent = esp32_evse_ns.class_("ESP32EVSEComponent")
+
 ESP32EVSEResetButton = esp32_evse_ns.class_(
-    "ESP32EVSEResetButton", button.Button, cg.Parented(ESP32EVSEComponent)
+    "ESP32EVSEResetButton", button.Button, cg.Parented.template(ESP32EVSEComponent)
 )
 
 BUTTONS_SCHEMA = cv.Schema(

--- a/components/esp32_evse/number.py
+++ b/components/esp32_evse/number.py
@@ -5,24 +5,37 @@ from __future__ import annotations
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import number
+from esphome.const import CONF_MAX_VALUE, CONF_MIN_VALUE, CONF_STEP
 
+from . import ESP32EVSEComponent
 from .const import CONF_CURRENT_LIMIT
 
 esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
-ESP32EVSEComponent = esp32_evse_ns.class_("ESP32EVSEComponent")
+
 ESP32EVSECurrentLimitNumber = esp32_evse_ns.class_(
-    "ESP32EVSECurrentLimitNumber", number.Number, cg.Parented(ESP32EVSEComponent)
+    "ESP32EVSECurrentLimitNumber", number.Number, cg.Parented.template(ESP32EVSEComponent)
 )
+
+def _validate_range(config: dict) -> dict:
+    if config[CONF_MIN_VALUE] >= config[CONF_MAX_VALUE]:
+        raise cv.Invalid("max_value must be greater than min_value")
+    return config
+
 
 NUMBERS_SCHEMA = cv.Schema(
     {
-        cv.Optional(CONF_CURRENT_LIMIT): number.number_schema(
-            ESP32EVSECurrentLimitNumber,
-            unit_of_measurement="A",
-            min_value=6.0,
-            max_value=32.0,
-            step=1.0,
-            mode=number.NUMBER_MODE_SLIDER,
+        cv.Optional(CONF_CURRENT_LIMIT): cv.All(
+            number.number_schema(
+                ESP32EVSECurrentLimitNumber,
+                unit_of_measurement="A",
+            ).extend(
+                {
+                    cv.Optional(CONF_MIN_VALUE, default=6.0): cv.float_,
+                    cv.Optional(CONF_MAX_VALUE, default=32.0): cv.float_,
+                    cv.Optional(CONF_STEP, default=1.0): cv.positive_float,
+                }
+            ),
+            _validate_range,
         )
     }
 )
@@ -33,6 +46,15 @@ async def setup_numbers(var: cg.Pvariable, config: dict | None) -> None:
         return
 
     if CONF_CURRENT_LIMIT in config:
-        num = await number.new_number(config[CONF_CURRENT_LIMIT])
+        num_config = config[CONF_CURRENT_LIMIT]
+        num = await number.new_number(
+            num_config,
+            min_value=num_config[CONF_MIN_VALUE],
+            max_value=num_config[CONF_MAX_VALUE],
+            step=num_config[CONF_STEP],
+        )
+
+        cg.add(num.traits.set_mode(number.NumberMode.SLIDER))
+
         cg.add(var.set_current_limit_number(num))
 

--- a/components/esp32_evse/switch.py
+++ b/components/esp32_evse/switch.py
@@ -7,12 +7,13 @@ import esphome.config_validation as cv
 from esphome.components import switch
 from esphome.const import ICON_FLASH
 
+from . import ESP32EVSEComponent
 from .const import CONF_CHARGING_SWITCH
 
 esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
-ESP32EVSEComponent = esp32_evse_ns.class_("ESP32EVSEComponent")
+
 ESP32EVSEChargingSwitch = esp32_evse_ns.class_(
-    "ESP32EVSEChargingSwitch", switch.Switch, cg.Parented(ESP32EVSEComponent)
+    "ESP32EVSEChargingSwitch", switch.Switch, cg.Parented.template(ESP32EVSEComponent)
 )
 
 SWITCHES_SCHEMA = cv.Schema(


### PR DESCRIPTION
## Summary
- import the shared `ESP32EVSEComponent` type before defining the switch, button, and number platforms so they inherit from the fully declared parent
- adapt the number platform to the updated ESPHome 2025 API by providing range parameters, validating them, and forcing the slider mode at runtime

## Testing
- `esphome config /tmp/test.yaml`

------
https://chatgpt.com/codex/tasks/task_e_68cd906869f08327b0b483e6eae7378d