### PR TITLE
Rewrite ESP32 EVSE platform modules to reuse base component

### DIFF
--- a/components/esp32_evse/__init__.py
+++ b/components/esp32_evse/__init__.py
@@ -1,16 +1,20 @@
-"""Code generation helpers for the ESP32 EVSE external component."""
+"""ESP32 EVSE core component definitions."""
+
+from __future__ import annotations
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart
 from esphome.const import CONF_ID, CONF_UPDATE_INTERVAL
 
-from . import sensor as sensor_config
-from . import text_sensor as text_sensor_config
-from . import switch as switch_config
-from . import button as button_config
-from . import number as number_config
-from .const import (
+esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
+ESP32EVSEComponent = esp32_evse_ns.class_(
+    "ESP32EVSEComponent",
+    cg.PollingComponent,
+    uart.UARTDevice,
+)
+
+from .const import (  # noqa: E402  (import after component declaration)
     CONF_BUTTONS,
     CONF_NUMBERS,
     CONF_SENSORS,
@@ -18,32 +22,32 @@ from .const import (
     CONF_TEXT_SENSORS,
     DEFAULT_UPDATE_INTERVAL,
 )
+from . import button as button_config  # noqa: E402
+from . import number as number_config  # noqa: E402
+from . import sensor as sensor_config  # noqa: E402
+from . import switch as switch_config  # noqa: E402
+from . import text_sensor as text_sensor_config  # noqa: E402
 
 AUTO_LOAD = ["sensor", "text_sensor", "number", "switch", "button"]
 DEPENDENCIES = ["uart"]
 
-esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
-ESP32EVSEComponent = esp32_evse_ns.class_(
-    "ESP32EVSEComponent", cg.PollingComponent, uart.UARTDevice
-)
-
-CONFIG_SCHEMA = (
-    cv.Schema({cv.GenerateID(): cv.declare_id(ESP32EVSEComponent)})
-    .extend(uart.UART_DEVICE_SCHEMA)
-    .extend(
-        {
-            cv.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL): cv.update_interval,
-            cv.Optional(CONF_SENSORS, default={}): sensor_config.SENSORS_SCHEMA,
-            cv.Optional(CONF_TEXT_SENSORS, default={}): text_sensor_config.TEXT_SENSORS_SCHEMA,
-            cv.Optional(CONF_SWITCHES, default={}): switch_config.SWITCHES_SCHEMA,
-            cv.Optional(CONF_BUTTONS, default={}): button_config.BUTTONS_SCHEMA,
-            cv.Optional(CONF_NUMBERS, default={}): number_config.NUMBERS_SCHEMA,
-        }
-    )
+CONFIG_SCHEMA = cv.Schema(
+    {cv.GenerateID(): cv.declare_id(ESP32EVSEComponent)}
+).extend(uart.UART_DEVICE_SCHEMA).extend(
+    {
+        cv.Optional(CONF_UPDATE_INTERVAL, default=DEFAULT_UPDATE_INTERVAL): cv.update_interval,
+        cv.Optional(CONF_SENSORS, default={}): sensor_config.SENSORS_SCHEMA,
+        cv.Optional(CONF_TEXT_SENSORS, default={}): text_sensor_config.TEXT_SENSORS_SCHEMA,
+        cv.Optional(CONF_SWITCHES, default={}): switch_config.SWITCHES_SCHEMA,
+        cv.Optional(CONF_BUTTONS, default={}): button_config.BUTTONS_SCHEMA,
+        cv.Optional(CONF_NUMBERS, default={}): number_config.NUMBERS_SCHEMA,
+    }
 )
 
 
-async def to_code(config):
+async def to_code(config: dict) -> None:
+    """Generate the C++ objects for the ESP32 EVSE component."""
+
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await uart.register_uart_device(var, config)

--- a/components/esp32_evse/button.py
+++ b/components/esp32_evse/button.py
@@ -1,4 +1,4 @@
-"""Button platform for the ESP32 EVSE external component."""
+"""Button platform bindings for the ESP32 EVSE component."""
 
 from __future__ import annotations
 
@@ -7,28 +7,31 @@ import esphome.config_validation as cv
 from esphome.components import button
 from esphome.const import ICON_RESTART
 
+from . import ESP32EVSEComponent
 from .const import CONF_RESET_BUTTON
 
 esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
-ESP32EVSEComponent = esp32_evse_ns.class_("ESP32EVSEComponent")
 ESP32EVSEResetButton = esp32_evse_ns.class_(
-    "ESP32EVSEResetButton", button.Button, cg.Parented(ESP32EVSEComponent)
+    "ESP32EVSEResetButton",
+    button.Button,
+    cg.Parented.template(ESP32EVSEComponent),
 )
 
 BUTTONS_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_RESET_BUTTON): button.button_schema(
-            ESP32EVSEResetButton, icon=ICON_RESTART
+            ESP32EVSEResetButton,
+            icon=ICON_RESTART,
         )
     }
 )
 
 
-async def setup_buttons(var: cg.Pvariable, config: dict | None) -> None:
-    if not config:
+async def setup_buttons(parent: cg.Pvariable, config: dict | None) -> None:
+    """Create the reset button when it is requested."""
+
+    if not config or CONF_RESET_BUTTON not in config:
         return
 
-    if CONF_RESET_BUTTON in config:
-        btn = await button.new_button(config[CONF_RESET_BUTTON])
-        cg.add(var.set_reset_button(btn))
-
+    btn = await button.new_button(config[CONF_RESET_BUTTON])
+    cg.add(parent.set_reset_button(btn))

--- a/components/esp32_evse/number.py
+++ b/components/esp32_evse/number.py
@@ -1,38 +1,61 @@
-"""Number platform for the ESP32 EVSE external component."""
+"""Number platform bindings for the ESP32 EVSE component."""
 
 from __future__ import annotations
 
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import number
+from esphome.const import CONF_MAX_VALUE, CONF_MIN_VALUE, CONF_STEP
 
+from . import ESP32EVSEComponent
 from .const import CONF_CURRENT_LIMIT
 
 esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
-ESP32EVSEComponent = esp32_evse_ns.class_("ESP32EVSEComponent")
 ESP32EVSECurrentLimitNumber = esp32_evse_ns.class_(
-    "ESP32EVSECurrentLimitNumber", number.Number, cg.Parented(ESP32EVSEComponent)
+    "ESP32EVSECurrentLimitNumber",
+    number.Number,
+    cg.Parented.template(ESP32EVSEComponent),
 )
+
+
+def _validate_range(config: dict) -> dict:
+    if config[CONF_MIN_VALUE] >= config[CONF_MAX_VALUE]:
+        raise cv.Invalid("max_value must be greater than min_value")
+    return config
+
 
 NUMBERS_SCHEMA = cv.Schema(
     {
-        cv.Optional(CONF_CURRENT_LIMIT): number.number_schema(
-            ESP32EVSECurrentLimitNumber,
-            unit_of_measurement="A",
-            min_value=6.0,
-            max_value=32.0,
-            step=1.0,
-            mode=number.NUMBER_MODE_SLIDER,
+        cv.Optional(CONF_CURRENT_LIMIT): cv.All(
+            number.number_schema(
+                ESP32EVSECurrentLimitNumber,
+                unit_of_measurement="A",
+            ).extend(
+                {
+                    cv.Optional(CONF_MIN_VALUE, default=6.0): cv.float_,
+                    cv.Optional(CONF_MAX_VALUE, default=32.0): cv.float_,
+                    cv.Optional(CONF_STEP, default=1.0): cv.positive_float,
+                }
+            ),
+            _validate_range,
         )
     }
 )
 
 
-async def setup_numbers(var: cg.Pvariable, config: dict | None) -> None:
-    if not config:
+async def setup_numbers(parent: cg.Pvariable, config: dict | None) -> None:
+    """Create the configurable number entities defined for the EVSE."""
+
+    if not config or CONF_CURRENT_LIMIT not in config:
         return
 
-    if CONF_CURRENT_LIMIT in config:
-        num = await number.new_number(config[CONF_CURRENT_LIMIT])
-        cg.add(var.set_current_limit_number(num))
+    num_config = config[CONF_CURRENT_LIMIT]
+    num = await number.new_number(
+        num_config,
+        min_value=num_config[CONF_MIN_VALUE],
+        max_value=num_config[CONF_MAX_VALUE],
+        step=num_config[CONF_STEP],
+    )
 
+    cg.add(num.traits.set_mode(number.NumberMode.SLIDER))
+    cg.add(parent.set_current_limit_number(num))

--- a/components/esp32_evse/switch.py
+++ b/components/esp32_evse/switch.py
@@ -1,4 +1,4 @@
-"""Switch platform for the ESP32 EVSE external component."""
+"""Switch platform bindings for the ESP32 EVSE component."""
 
 from __future__ import annotations
 
@@ -7,29 +7,31 @@ import esphome.config_validation as cv
 from esphome.components import switch
 from esphome.const import ICON_FLASH
 
+from . import ESP32EVSEComponent
 from .const import CONF_CHARGING_SWITCH
 
 esp32_evse_ns = cg.esphome_ns.namespace("esp32_evse")
-ESP32EVSEComponent = esp32_evse_ns.class_("ESP32EVSEComponent")
 ESP32EVSEChargingSwitch = esp32_evse_ns.class_(
-    "ESP32EVSEChargingSwitch", switch.Switch, cg.Parented(ESP32EVSEComponent)
+    "ESP32EVSEChargingSwitch",
+    switch.Switch,
+    cg.Parented.template(ESP32EVSEComponent),
 )
 
 SWITCHES_SCHEMA = cv.Schema(
     {
-        cv.Optional(CONF_CHARGING_SWITCH): switch.switch_schema(ESP32EVSEChargingSwitch).extend(
-            {cv.Optional("icon", default=ICON_FLASH): cv.icon},
+        cv.Optional(CONF_CHARGING_SWITCH): switch.switch_schema(
+            ESP32EVSEChargingSwitch,
+            icon=ICON_FLASH,
         )
     }
 )
 
 
-async def setup_switches(var: cg.Pvariable, config: dict | None) -> None:
-    if not config:
+async def setup_switches(parent: cg.Pvariable, config: dict | None) -> None:
+    """Create the charging switch if it is present in the configuration."""
+
+    if not config or CONF_CHARGING_SWITCH not in config:
         return
 
-    if CONF_CHARGING_SWITCH in config:
-        sw_config = config[CONF_CHARGING_SWITCH]
-        sw = await switch.new_switch(sw_config)
-        cg.add(var.set_charging_switch(sw))
-
+    sw = await switch.new_switch(config[CONF_CHARGING_SWITCH])
+    cg.add(parent.set_charging_switch(sw))


### PR DESCRIPTION
## Summary
- rebuild the ESP32 EVSE component module so the namespace and component class are created before loading platform helpers
- regenerate the switch, button, and number platform bindings to import the shared component type and streamline their setup helpers

## Testing
- esphome config /tmp/test.yaml *(fails in container: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd906869f08327b0b483e6eae7378d