### PR TITLE
Resolve ESP32 EVSE command handling build issues

### DIFF
--- a/components/esp32evse/__init__.py
+++ b/components/esp32evse/__init__.py
@@ -1,0 +1,31 @@
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome.components import uart
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ["uart"]
+DEPENDENCIES = ["uart"]
+CODEOWNERS = ["@dzurikmiroslav"]
+
+esp32evse_ns = cg.esphome_ns.namespace("esp32evse")
+ESP32EVSEComponent = esp32evse_ns.class_(
+    "ESP32EVSEComponent", cg.Component, uart.UARTDevice
+)
+
+CONF_ESP32EVSE_ID = "esp32evse_id"
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema({cv.GenerateID(): cv.declare_id(ESP32EVSEComponent)})
+    .extend(uart.UART_DEVICE_SCHEMA)
+    .extend(cv.COMPONENT_SCHEMA)
+)
+
+FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(
+    "esp32evse", require_tx=True, require_rx=True
+)
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await uart.register_uart_device(var, config)

--- a/components/esp32evse/button.py
+++ b/components/esp32evse/button.py
@@ -1,0 +1,48 @@
+import esphome.codegen as cg
+from esphome.components import button
+import esphome.config_validation as cv
+
+from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
+
+DEPENDENCIES = ["esp32evse"]
+
+ESP32EVSEFastSubscribeButton = esp32evse_ns.class_(
+    "ESP32EVSEFastSubscribeButton", button.Button
+)
+ESP32EVSEFastUnsubscribeButton = esp32evse_ns.class_(
+    "ESP32EVSEFastUnsubscribeButton", button.Button
+)
+
+CONF_FAST_SUBSCRIBE = "fast_power_subscribe"
+CONF_FAST_UNSUBSCRIBE = "fast_power_unsubscribe"
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
+            cv.Optional(CONF_FAST_SUBSCRIBE): button.button_schema(
+                ESP32EVSEFastSubscribeButton,
+                icon="mdi:speedometer",
+            ),
+            cv.Optional(CONF_FAST_UNSUBSCRIBE): button.button_schema(
+                ESP32EVSEFastUnsubscribeButton,
+                icon="mdi:speedometer-slow",
+            ),
+        }
+    ),
+    cv.has_at_least_one_key(CONF_FAST_SUBSCRIBE, CONF_FAST_UNSUBSCRIBE),
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_ESP32EVSE_ID])
+
+    if subscribe_config := config.get(CONF_FAST_SUBSCRIBE):
+        btn = await button.new_button(subscribe_config)
+        await cg.register_parented(btn, config[CONF_ESP32EVSE_ID])
+        cg.add(parent.set_fast_subscribe_button(btn))
+    if unsubscribe_config := config.get(CONF_FAST_UNSUBSCRIBE):
+        btn = await button.new_button(unsubscribe_config)
+        await cg.register_parented(btn, config[CONF_ESP32EVSE_ID])
+        cg.add(parent.set_fast_unsubscribe_button(btn))

--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -1,0 +1,316 @@
+#include "esp32evse.h"
+
+#include "esphome/core/helpers.h"
+#include "esphome/core/log.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <inttypes.h>
+
+namespace esphome {
+namespace esp32evse {
+
+static const char *const TAG = "esp32evse";
+
+void ESP32EVSEComponent::setup() {
+  ESP_LOGCONFIG(TAG, "Setting up ESP32 EVSE component");
+
+  // Initial queries
+  this->set_timeout(1000, [this]() {
+    this->request_state_update();
+    this->request_enable_update();
+    this->request_temperature_update();
+    this->request_charging_current_update();
+    this->request_emeter_power_update();
+    this->request_emeter_session_time_update();
+    this->request_emeter_charging_time_update();
+
+    // Subscribe to state and enable updates every second by default
+    this->send_command_("AT+SUB=\"+STATE\",1000");
+    this->send_command_("AT+SUB=\"+ENABLE\",1000");
+    if (this->emeter_power_sensor_ != nullptr) {
+      this->send_command_("AT+SUB=\"+EMETERPOWER\",1000");
+    }
+  });
+
+  if (this->temperature_sensor_ != nullptr) {
+    this->set_interval("temp_poll", 60000, [this]() { this->request_temperature_update(); });
+  }
+  if (this->emeter_power_sensor_ != nullptr) {
+    this->set_interval("emeter_power_poll", 30000, [this]() { this->request_emeter_power_update(); });
+  }
+  if (this->emeter_session_time_sensor_ != nullptr) {
+    this->set_interval("emeter_ses_time_poll", 10000,
+                       [this]() { this->request_emeter_session_time_update(); });
+  }
+  if (this->emeter_charging_time_sensor_ != nullptr) {
+    this->set_interval("emeter_ch_time_poll", 10000,
+                       [this]() { this->request_emeter_charging_time_update(); });
+  }
+  if (this->charging_current_number_ != nullptr) {
+    this->set_interval("chcur_poll", 60000, [this]() { this->request_charging_current_update(); });
+  }
+}
+
+void ESP32EVSEComponent::loop() {
+  while (this->available()) {
+    uint8_t byte;
+    this->read_byte(&byte);
+    char c = static_cast<char>(byte);
+    if (c == '\r')
+      continue;
+    if (c == '\n') {
+      if (!this->read_buffer_.empty()) {
+        this->process_line_(this->read_buffer_);
+        this->read_buffer_.clear();
+      }
+    } else {
+      this->read_buffer_.push_back(c);
+      if (this->read_buffer_.size() > 256) {
+        ESP_LOGW(TAG, "Line too long, resetting buffer");
+        this->read_buffer_.clear();
+      }
+    }
+  }
+
+  // Handle command timeouts (5 seconds)
+  const uint32_t now = millis();
+  while (!this->pending_commands_.empty()) {
+    auto &front = this->pending_commands_.front();
+    if (now - front.start_time < 5000) {
+      break;
+    }
+    ESP_LOGW(TAG, "Command '%s' timed out", front.command.c_str());
+    if (front.callback)
+      front.callback(false);
+    this->pending_commands_.pop_front();
+  }
+}
+
+void ESP32EVSEComponent::dump_config() {
+  ESP_LOGCONFIG(TAG, "ESP32 EVSE:");
+  if (this->temperature_sensor_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Temperature polling interval: 60s");
+  }
+  if (this->emeter_power_sensor_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Energy meter power polling interval: 30s");
+  }
+  if (this->emeter_session_time_sensor_ != nullptr || this->emeter_charging_time_sensor_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Energy meter time polling interval: 10s");
+  }
+  if (this->charging_current_number_ != nullptr) {
+    ESP_LOGCONFIG(TAG, "  Charging current polling interval: 60s");
+  }
+}
+
+void ESP32EVSEComponent::request_state_update() { this->send_command_("AT+STATE?"); }
+void ESP32EVSEComponent::request_enable_update() { this->send_command_("AT+ENABLE?"); }
+void ESP32EVSEComponent::request_temperature_update() { this->send_command_("AT+TEMP?"); }
+void ESP32EVSEComponent::request_charging_current_update() { this->send_command_("AT+CHCUR?"); }
+void ESP32EVSEComponent::request_emeter_power_update() { this->send_command_("AT+EMETERPOWER?"); }
+void ESP32EVSEComponent::request_emeter_session_time_update() {
+  this->send_command_("AT+EMETERSESTIME?");
+}
+void ESP32EVSEComponent::request_emeter_charging_time_update() {
+  this->send_command_("AT+EMETERCHTIME?");
+}
+
+void ESP32EVSEComponent::write_enable_state(bool enabled) {
+  std::string command = "AT+ENABLE=";
+  command += enabled ? '1' : '0';
+  this->send_command_(command, [this, enabled](bool success) {
+    if (!success && this->enable_switch_ != nullptr) {
+      this->enable_switch_->publish_state(!enabled);
+    }
+  });
+}
+
+void ESP32EVSEComponent::write_charging_current(float current) {
+  if (current < 6.0f)
+    current = 6.0f;
+  else if (current > 63.0f)
+    current = 63.0f;
+  uint16_t tenths = static_cast<uint16_t>(std::roundf(current * 10.0f));
+  std::string command = "AT+CHCUR=" + std::to_string(tenths);
+  this->send_command_(command, [this](bool success) {
+    if (!success && this->charging_current_number_ != nullptr) {
+      this->request_charging_current_update();
+    }
+  });
+}
+
+void ESP32EVSEComponent::subscribe_fast_power_updates() {
+  this->send_command_("AT+SUB=\"+EMETERPOWER\",500");
+}
+
+void ESP32EVSEComponent::unsubscribe_fast_power_updates() {
+  this->send_command_("AT+UNSUB=\"+EMETERPOWER\"");
+}
+
+void ESP32EVSEComponent::send_command_(const std::string &command, std::function<void(bool)> callback) {
+  ESP_LOGV(TAG, "Sending command: %s", command.c_str());
+  this->write_str(command.c_str());
+  this->write_str("\r\n");
+  PendingCommand pending{command, std::move(callback), millis()};
+  this->pending_commands_.push_back(std::move(pending));
+}
+
+void ESP32EVSEComponent::process_line_(const std::string &line) {
+  ESP_LOGV(TAG, "Received line: %s", line.c_str());
+  if (line == "OK") {
+    this->handle_ack_(true);
+    return;
+  }
+  if (line == "ERROR") {
+    this->handle_ack_(false);
+    return;
+  }
+  if (line.rfind("+STATE=", 0) == 0) {
+    int value = atoi(line.c_str() + 7);
+    this->update_state_(value);
+    return;
+  }
+  if (line.rfind("+ENABLE=", 0) == 0) {
+    int value = atoi(line.c_str() + 8);
+    this->update_enable_(value == 1);
+    return;
+  }
+  if (line.rfind("+TEMP=", 0) == 0) {
+    int count = 0;
+    int32_t high = 0;
+    int32_t low = 0;
+    if (sscanf(line.c_str(), "+TEMP=%d,%" PRIi32 ",%" PRIi32, &count, &high, &low) == 3) {
+      this->update_temperature_(count, high, low);
+    }
+    return;
+  }
+  if (line.rfind("+CHCUR=", 0) == 0) {
+    int value = atoi(line.c_str() + 7);
+    if (value >= 0)
+      this->update_charging_current_(static_cast<uint16_t>(value));
+    return;
+  }
+  if (line.rfind("+EMETERPOWER=", 0) == 0) {
+    uint32_t power = static_cast<uint32_t>(strtoul(line.c_str() + 13, nullptr, 10));
+    this->update_emeter_power_(power);
+    return;
+  }
+  if (line.rfind("+EMETERSESTIME=", 0) == 0) {
+    uint32_t time = static_cast<uint32_t>(strtoul(line.c_str() + 15, nullptr, 10));
+    this->update_emeter_session_time_(time);
+    return;
+  }
+  if (line.rfind("+EMETERCHTIME=", 0) == 0) {
+    uint32_t time = static_cast<uint32_t>(strtoul(line.c_str() + 14, nullptr, 10));
+    this->update_emeter_charging_time_(time);
+    return;
+  }
+  ESP_LOGD(TAG, "Unhandled line: %s", line.c_str());
+}
+
+void ESP32EVSEComponent::handle_ack_(bool success) {
+  if (this->pending_commands_.empty()) {
+    ESP_LOGW(TAG, "Received %s without pending command", success ? "OK" : "ERROR");
+    return;
+  }
+  auto pending = this->pending_commands_.front();
+  this->pending_commands_.pop_front();
+  ESP_LOGV(TAG, "Command '%s' completed with %s", pending.command.c_str(), success ? "OK" : "ERROR");
+  if (pending.callback)
+    pending.callback(success);
+}
+
+void ESP32EVSEComponent::update_state_(uint8_t state) {
+  static const char *const STATE_NAMES[] = {"A", "B1", "B2", "C1", "C2", "D1", "D2", "E", "F"};
+  const char *state_name = "UNKNOWN";
+  if (state < sizeof(STATE_NAMES) / sizeof(STATE_NAMES[0])) {
+    state_name = STATE_NAMES[state];
+  }
+  if (this->state_text_sensor_ != nullptr) {
+    this->state_text_sensor_->publish_state(state_name);
+  }
+}
+
+void ESP32EVSEComponent::update_enable_(bool enable) {
+  if (this->enable_switch_ != nullptr) {
+    this->enable_switch_->publish_state(enable);
+  }
+}
+
+void ESP32EVSEComponent::update_temperature_(int count, int32_t high, int32_t low) {
+  if (this->temperature_sensor_ == nullptr)
+    return;
+  if (count <= 0) {
+    this->temperature_sensor_->publish_state(NAN);
+    return;
+  }
+  float high_c = high / 100.0f;
+  float low_c = low / 100.0f;
+  ESP_LOGD(TAG, "Temperature sensors: %d, high %.2f°C, low %.2f°C", count, high_c, low_c);
+  this->temperature_sensor_->publish_state(high_c);
+}
+
+void ESP32EVSEComponent::update_charging_current_(uint16_t value_tenths) {
+  if (this->charging_current_number_ != nullptr) {
+    float current = value_tenths / 10.0f;
+    this->charging_current_number_->publish_state(current);
+  }
+}
+
+void ESP32EVSEComponent::update_emeter_power_(uint32_t power_w) {
+  if (this->emeter_power_sensor_ != nullptr) {
+    this->emeter_power_sensor_->publish_state(power_w);
+  }
+}
+
+void ESP32EVSEComponent::update_emeter_session_time_(uint32_t time_s) {
+  if (this->emeter_session_time_sensor_ != nullptr) {
+    this->emeter_session_time_sensor_->publish_state(time_s);
+  }
+}
+
+void ESP32EVSEComponent::update_emeter_charging_time_(uint32_t time_s) {
+  if (this->emeter_charging_time_sensor_ != nullptr) {
+    this->emeter_charging_time_sensor_->publish_state(time_s);
+  }
+}
+
+void ESP32EVSEEnableSwitch::write_state(bool state) {
+  if (this->parent_ == nullptr)
+    return;
+  this->publish_state(state);
+  this->parent_->write_enable_state(state);
+}
+
+void ESP32EVSEChargingCurrentNumber::control(float value) {
+  if (this->parent_ == nullptr)
+    return;
+  if (value < 6.0f)
+    value = 6.0f;
+  else if (value > 63.0f)
+    value = 63.0f;
+  this->publish_state(value);
+  this->parent_->write_charging_current(value);
+}
+
+ESP32EVSEChargingCurrentNumber::ESP32EVSEChargingCurrentNumber() {
+  this->traits_.set_min_value(6.0f);
+  this->traits_.set_max_value(63.0f);
+  this->traits_.set_step(0.1f);
+}
+
+void ESP32EVSEFastSubscribeButton::press_action() {
+  if (this->parent_ == nullptr)
+    return;
+  this->parent_->subscribe_fast_power_updates();
+}
+
+void ESP32EVSEFastUnsubscribeButton::press_action() {
+  if (this->parent_ == nullptr)
+    return;
+  this->parent_->unsubscribe_fast_power_updates();
+}
+
+}  // namespace esp32evse
+}  // namespace esphome

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -1,0 +1,119 @@
+#pragma once
+
+#include "esphome/components/button/button.h"
+#include "esphome/components/number/number.h"
+#include "esphome/components/sensor/sensor.h"
+#include "esphome/components/switch/switch.h"
+#include "esphome/components/text_sensor/text_sensor.h"
+#include "esphome/components/uart/uart.h"
+#include "esphome/core/component.h"
+#include "esphome/core/defines.h"
+#include "esphome/core/hal.h"
+
+#include <deque>
+#include <functional>
+#include <string>
+
+namespace esphome {
+namespace esp32evse {
+
+class ESP32EVSEEnableSwitch;
+class ESP32EVSEChargingCurrentNumber;
+class ESP32EVSEFastSubscribeButton;
+class ESP32EVSEFastUnsubscribeButton;
+
+class ESP32EVSEComponent : public uart::UARTDevice, public Component {
+ public:
+  void setup() override;
+  void loop() override;
+  void dump_config() override;
+
+  void set_state_text_sensor(text_sensor::TextSensor *sensor) { this->state_text_sensor_ = sensor; }
+  void set_enable_switch(ESP32EVSEEnableSwitch *sw) { this->enable_switch_ = sw; }
+  void set_temperature_sensor(sensor::Sensor *sensor) { this->temperature_sensor_ = sensor; }
+  void set_charging_current_number(ESP32EVSEChargingCurrentNumber *number) {
+    this->charging_current_number_ = number;
+  }
+  void set_emeter_power_sensor(sensor::Sensor *sensor) { this->emeter_power_sensor_ = sensor; }
+  void set_emeter_session_time_sensor(sensor::Sensor *sensor) {
+    this->emeter_session_time_sensor_ = sensor;
+  }
+  void set_emeter_charging_time_sensor(sensor::Sensor *sensor) {
+    this->emeter_charging_time_sensor_ = sensor;
+  }
+  void set_fast_subscribe_button(ESP32EVSEFastSubscribeButton *btn) { this->fast_subscribe_button_ = btn; }
+  void set_fast_unsubscribe_button(ESP32EVSEFastUnsubscribeButton *btn) {
+    this->fast_unsubscribe_button_ = btn;
+  }
+
+  void request_state_update();
+  void request_enable_update();
+  void request_temperature_update();
+  void request_charging_current_update();
+  void request_emeter_power_update();
+  void request_emeter_session_time_update();
+  void request_emeter_charging_time_update();
+
+  void write_enable_state(bool enabled);
+  void write_charging_current(float current);
+  void subscribe_fast_power_updates();
+  void unsubscribe_fast_power_updates();
+
+ protected:
+  struct PendingCommand {
+    std::string command;
+    std::function<void(bool)> callback;
+    uint32_t start_time;
+  };
+
+  void process_line_(const std::string &line);
+  void handle_ack_(bool success);
+  void update_state_(uint8_t state);
+  void update_enable_(bool enable);
+  void update_temperature_(int count, int32_t high, int32_t low);
+  void update_charging_current_(uint16_t value_tenths);
+  void update_emeter_power_(uint32_t power_w);
+  void update_emeter_session_time_(uint32_t time_s);
+  void update_emeter_charging_time_(uint32_t time_s);
+
+  void send_command_(const std::string &command, std::function<void(bool)> callback = nullptr);
+
+  text_sensor::TextSensor *state_text_sensor_{nullptr};
+  ESP32EVSEEnableSwitch *enable_switch_{nullptr};
+  sensor::Sensor *temperature_sensor_{nullptr};
+  ESP32EVSEChargingCurrentNumber *charging_current_number_{nullptr};
+  sensor::Sensor *emeter_power_sensor_{nullptr};
+  sensor::Sensor *emeter_session_time_sensor_{nullptr};
+  sensor::Sensor *emeter_charging_time_sensor_{nullptr};
+  ESP32EVSEFastSubscribeButton *fast_subscribe_button_{nullptr};
+  ESP32EVSEFastUnsubscribeButton *fast_unsubscribe_button_{nullptr};
+
+  std::string read_buffer_;
+  std::deque<PendingCommand> pending_commands_;
+};
+
+class ESP32EVSEEnableSwitch : public switch_::Switch, public Parented<ESP32EVSEComponent> {
+ protected:
+  void write_state(bool state) override;
+};
+
+class ESP32EVSEChargingCurrentNumber : public number::Number, public Parented<ESP32EVSEComponent> {
+ public:
+  ESP32EVSEChargingCurrentNumber();
+
+ protected:
+  void control(float value) override;
+};
+
+class ESP32EVSEFastSubscribeButton : public button::Button, public Parented<ESP32EVSEComponent> {
+ protected:
+  void press_action() override;
+};
+
+class ESP32EVSEFastUnsubscribeButton : public button::Button, public Parented<ESP32EVSEComponent> {
+ protected:
+  void press_action() override;
+};
+
+}  // namespace esp32evse
+}  // namespace esphome

--- a/components/esp32evse/number.py
+++ b/components/esp32evse/number.py
@@ -1,0 +1,37 @@
+import esphome.codegen as cg
+from esphome.components import number
+import esphome.config_validation as cv
+
+from esphome.const import UNIT_AMPERE
+
+from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
+
+DEPENDENCIES = ["esp32evse"]
+
+ESP32EVSEChargingCurrentNumber = esp32evse_ns.class_(
+    "ESP32EVSEChargingCurrentNumber", number.Number
+)
+
+CONF_CHARGING_CURRENT = "charging_current"
+
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
+        cv.Required(CONF_CHARGING_CURRENT): number.number_schema(
+            ESP32EVSEChargingCurrentNumber,
+            icon="mdi:current-ac",
+            unit_of_measurement=UNIT_AMPERE,
+            min_value=6.0,
+            max_value=63.0,
+            step=0.1,
+        ),
+    }
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_ESP32EVSE_ID])
+    num = await number.new_number(config[CONF_CHARGING_CURRENT])
+    await cg.register_parented(num, config[CONF_ESP32EVSE_ID])
+    cg.add(parent.set_charging_current_number(num))

--- a/components/esp32evse/sensor.py
+++ b/components/esp32evse/sensor.py
@@ -1,0 +1,76 @@
+import esphome.codegen as cg
+from esphome.components import sensor
+import esphome.config_validation as cv
+from esphome.const import (
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_TEMPERATURE,
+    ICON_FLASH,
+    ICON_THERMOMETER,
+    ICON_TIMER,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_CELSIUS,
+    UNIT_SECOND,
+)
+
+from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent
+
+DEPENDENCIES = ["esp32evse"]
+
+CONF_TEMPERATURE = "temperature"
+CONF_EMETER_POWER = "emeter_power"
+CONF_EMETER_SESSION_TIME = "emeter_session_time"
+CONF_EMETER_CHARGING_TIME = "emeter_charging_time"
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
+            cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                icon=ICON_THERMOMETER,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_EMETER_POWER): sensor.sensor_schema(
+                device_class=DEVICE_CLASS_POWER,
+                state_class=STATE_CLASS_MEASUREMENT,
+                unit_of_measurement="W",
+                icon=ICON_FLASH,
+            ),
+            cv.Optional(CONF_EMETER_SESSION_TIME): sensor.sensor_schema(
+                unit_of_measurement=UNIT_SECOND,
+                icon=ICON_TIMER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_EMETER_CHARGING_TIME): sensor.sensor_schema(
+                unit_of_measurement=UNIT_SECOND,
+                icon=ICON_TIMER,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+        }
+    ),
+    cv.has_at_least_one_key(
+        CONF_TEMPERATURE,
+        CONF_EMETER_POWER,
+        CONF_EMETER_SESSION_TIME,
+        CONF_EMETER_CHARGING_TIME,
+    ),
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_ESP32EVSE_ID])
+
+    if temperature_config := config.get(CONF_TEMPERATURE):
+        sens = await sensor.new_sensor(temperature_config)
+        cg.add(parent.set_temperature_sensor(sens))
+    if power_config := config.get(CONF_EMETER_POWER):
+        sens = await sensor.new_sensor(power_config)
+        cg.add(parent.set_emeter_power_sensor(sens))
+    if session_config := config.get(CONF_EMETER_SESSION_TIME):
+        sens = await sensor.new_sensor(session_config)
+        cg.add(parent.set_emeter_session_time_sensor(sens))
+    if charging_config := config.get(CONF_EMETER_CHARGING_TIME):
+        sens = await sensor.new_sensor(charging_config)
+        cg.add(parent.set_emeter_charging_time_sensor(sens))

--- a/components/esp32evse/switch.py
+++ b/components/esp32evse/switch.py
@@ -1,0 +1,31 @@
+import esphome.codegen as cg
+from esphome.components import switch
+import esphome.config_validation as cv
+
+from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
+
+DEPENDENCIES = ["esp32evse"]
+
+ESP32EVSEEnableSwitch = esp32evse_ns.class_("ESP32EVSEEnableSwitch", switch.Switch)
+
+CONF_ENABLE = "enable"
+
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
+        cv.Required(CONF_ENABLE): switch.switch_schema(
+            ESP32EVSEEnableSwitch,
+            icon="mdi:toggle-switch",
+        ),
+    }
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_ESP32EVSE_ID])
+
+    enable_config = config[CONF_ENABLE]
+    sw = await switch.new_switch(enable_config)
+    await cg.register_parented(sw, config[CONF_ESP32EVSE_ID])
+    cg.add(parent.set_enable_switch(sw))

--- a/components/esp32evse/text_sensor.py
+++ b/components/esp32evse/text_sensor.py
@@ -1,0 +1,25 @@
+import esphome.codegen as cg
+from esphome.components import text_sensor
+import esphome.config_validation as cv
+
+from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent
+
+DEPENDENCIES = ["esp32evse"]
+
+CONF_STATE = "state"
+
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
+        cv.Required(CONF_STATE): text_sensor.text_sensor_schema(icon="mdi:ev-station"),
+    }
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_ESP32EVSE_ID])
+
+    state_config = config[CONF_STATE]
+    sens = await text_sensor.new_text_sensor(state_config)
+    cg.add(parent.set_state_text_sensor(sens))

--- a/src/esphome.yaml
+++ b/src/esphome.yaml
@@ -1,1 +1,74 @@
+esphome:
+  name: esp32evse_dev
+  platform: ESP32
+  board: esp32dev
 
+logger:
+  level: DEBUG
+
+wifi:
+  ssid: "YOUR_WIFI"
+  password: "YOUR_PASSWORD"
+  ap:
+    ssid: "esp32evse"
+    password: "changeme"
+
+captive_portal:
+
+api:
+
+ota:
+
+uart:
+  id: evse_uart
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+  baud_rate: 115200
+
+external_components:
+  - source:
+      type: local
+      path: ../components
+    components: [esp32evse]
+
+esp32evse:
+  id: evse
+  uart_id: evse_uart
+
+text_sensor:
+  - platform: esp32evse
+    esp32evse_id: evse
+    state:
+      name: "EVSE State"
+
+switch:
+  - platform: esp32evse
+    esp32evse_id: evse
+    enable:
+      name: "EVSE Charging Enable"
+
+sensor:
+  - platform: esp32evse
+    esp32evse_id: evse
+    temperature:
+      name: "EVSE Temperature"
+    emeter_power:
+      name: "EVSE Power"
+    emeter_session_time:
+      name: "EVSE Session Time"
+    emeter_charging_time:
+      name: "EVSE Charging Time"
+
+number:
+  - platform: esp32evse
+    esp32evse_id: evse
+    charging_current:
+      name: "EVSE Charging Current"
+
+button:
+  - platform: esp32evse
+    esp32evse_id: evse
+    fast_power_subscribe:
+      name: "EVSE Fast Power Subscribe"
+    fast_power_unsubscribe:
+      name: "EVSE Fast Power Unsubscribe"


### PR DESCRIPTION
## Summary
- remove the deprecated LOG_UART_DEVICE macro usage and log the configured EVSE polling intervals instead
- clamp the charging current to the supported 6–63 A range, set the runtime traits in the number constructor, and expose the same range in the platform schema
- simplify UART command transmission so commands are queued without treating write_str as returning a status flag

## Testing
- python -m compileall components

------
https://chatgpt.com/codex/tasks/task_e_68d1655c042c83279cf0111953da8f15