### PR TITLE
Ensure charging current number schema provides firmware limits

### DIFF
--- a/components/esp32evse/number.py
+++ b/components/esp32evse/number.py
@@ -1,3 +1,5 @@
+import inspect
+
 import esphome.codegen as cg
 from esphome.components import number
 import esphome.config_validation as cv
@@ -15,13 +17,27 @@ ESP32EVSEChargingCurrentNumber = esp32evse_ns.class_(
 CONF_CHARGING_CURRENT = "charging_current"
 
 
+_NUMBER_SCHEMA_KWARGS = {
+    "icon": "mdi:current-ac",
+    "unit_of_measurement": UNIT_AMPERE,
+}
+
+if "min_value" in inspect.signature(number.number_schema).parameters:
+    _NUMBER_SCHEMA_KWARGS.update(
+        {
+            "min_value": 6.0,
+            "max_value": 63.0,
+            "step": 0.1,
+        }
+    )
+
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
         cv.Required(CONF_CHARGING_CURRENT): number.number_schema(
             ESP32EVSEChargingCurrentNumber,
-            icon="mdi:current-ac",
-            unit_of_measurement=UNIT_AMPERE,
+            **_NUMBER_SCHEMA_KWARGS,
         ).extend(
             {
                 cv.Optional(CONF_MIN_VALUE, default=6.0): cv.float_,

--- a/src/esphome.yaml
+++ b/src/esphome.yaml
@@ -1,6 +1,7 @@
 esphome:
   name: esp32evse_dev
-  platform: ESP32
+
+esp32:
   board: esp32dev
 
 logger:


### PR DESCRIPTION
## Summary
- extend the charging current number schema to always inject the EVSE firmware limits (6–63 A at 0.1 A resolution) when supported by the running ESPHome version
- keep explicit schema defaults for min/max/step so older ESPHome releases still populate the configuration as expected
- update the example configuration to the current `esp32:` section format so validation succeeds on modern ESPHome builds

## Testing
- `esphome config src/esphome.yaml`
- `esphome compile src/esphome.yaml` *(fails: esphome core raises `TypeError: 'int' object is not subscriptable` while iterating component configs)*

------
https://chatgpt.com/codex/tasks/task_e_68d3985945948327af13565c8b3f0f5b