### PR TITLE
Fix charging current number traits handling

### DIFF
--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -276,12 +276,10 @@ void ESP32EVSEEnableSwitch::write_state(bool state) {
   this->parent_->write_enable_state(state);
 }
 
-number::NumberTraits ESP32EVSEChargingCurrentNumber::traits() {
-  auto traits = number::NumberTraits();
-  traits.set_min_value(6.0f);
-  traits.set_max_value(63.0f);
-  traits.set_step(0.1f);
-  return traits;
+ESP32EVSEChargingCurrentNumber::ESP32EVSEChargingCurrentNumber() {
+  this->traits.set_min_value(6.0f);
+  this->traits.set_max_value(63.0f);
+  this->traits.set_step(0.1f);
 }
 
 void ESP32EVSEChargingCurrentNumber::control(float value) {

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -98,8 +98,10 @@ class ESP32EVSEEnableSwitch : public switch_::Switch, public Parented<ESP32EVSEC
 };
 
 class ESP32EVSEChargingCurrentNumber : public number::Number, public Parented<ESP32EVSEComponent> {
+ public:
+  ESP32EVSEChargingCurrentNumber();
+
  protected:
-  number::NumberTraits traits() override;
   void control(float value) override;
 };
 


### PR DESCRIPTION
## Summary
- remove the traits() override from the charging current number implementation
- configure the number limits in the constructor to preserve the runtime behavior

## Testing
- esphome compile src/esphome.yaml *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d39a1063b88327b8a37f9d8da80722