### PR TITLE
Refine UART diagnostics in ESP32 EVSE dump

### DIFF
--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -90,7 +90,19 @@ void ESP32EVSEComponent::loop() {
 
 void ESP32EVSEComponent::dump_config() {
   ESP_LOGCONFIG(TAG, "ESP32 EVSE:");
-  LOG_UART_DEVICE(this);
+  auto *uart_parent = this->parent_;
+  if (uart_parent != nullptr) {
+    ESP_LOGCONFIG(TAG, "  UART Baud Rate: %u", uart_parent->get_baud_rate());
+    ESP_LOGCONFIG(TAG, "  UART Data Bits: %u", uart_parent->get_data_bits());
+    ESP_LOGCONFIG(TAG, "  UART Parity: %s", LOG_STR_ARG(uart::parity_to_str(uart_parent->get_parity())));
+    ESP_LOGCONFIG(TAG, "  UART Stop Bits: %u", uart_parent->get_stop_bits());
+    size_t rx_buffer_size = uart_parent->get_rx_buffer_size();
+    if (rx_buffer_size != 0) {
+      ESP_LOGCONFIG(TAG, "  UART RX Buffer Size: %u", rx_buffer_size);
+    }
+  } else {
+    ESP_LOGW(TAG, "  No UART parent configured");
+  }
 }
 
 void ESP32EVSEComponent::request_state_update() { this->send_command_("AT+STATE?"); }


### PR DESCRIPTION
## Summary
- replace usage of removed LOG_UART_DEVICE macro with explicit UART diagnostic logging in the ESP32 EVSE component
- add defensive handling when no UART parent is configured while dumping configuration

## Testing
- esphome compile src/esphome_test.yaml *(fails: existing component incompatibilities with ESPHome 2024.6.0, confirms undefined macro error resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68d3a02cfb688327ba09711ae34e1c81