### PR TITLE
Handle carriage returns and relax line length limit

### DIFF
--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -58,17 +58,15 @@ void ESP32EVSEComponent::loop() {
     uint8_t byte;
     this->read_byte(&byte);
     char c = static_cast<char>(byte);
-    if (c == '\r')
-      continue;
-    if (c == '\n') {
+    if (c == '\n' || c == '\r') {
       if (!this->read_buffer_.empty()) {
         this->process_line_(this->read_buffer_);
         this->read_buffer_.clear();
       }
     } else {
       this->read_buffer_.push_back(c);
-      if (this->read_buffer_.size() > 256) {
-        ESP_LOGW(TAG, "Line too long, resetting buffer");
+      if (this->read_buffer_.size() > 512) {
+        ESP_LOGW(TAG, "Line too long (%zu), discarding partial data", this->read_buffer_.size());
         this->read_buffer_.clear();
       }
     }


### PR DESCRIPTION
## Summary
- treat both carriage return and newline as line terminators when parsing UART responses
- allow longer partial lines before they are discarded to reduce spurious warnings

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d3a79b7da88327ab828b95adaea79a