### PR TITLE
Default temperature accuracy to two decimals

### DIFF
--- a/components/esp32evse/sensor.py
+++ b/components/esp32evse/sensor.py
@@ -31,6 +31,7 @@ CONFIG_SCHEMA = cv.All(
                 icon=ICON_THERMOMETER,
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
+                accuracy_decimals=2,
             ),
             cv.Optional(CONF_EMETER_POWER): sensor.sensor_schema(
                 device_class=DEVICE_CLASS_POWER,


### PR DESCRIPTION
## Summary
- set the ESP32 EVSE temperature sensor schema to default to two decimal places
- remove the explicit `accuracy_decimals` override from the example YAML configuration

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3ad5079f08327be47e0c7fec2b3ca