### PR TITLE
Adjust polling intervals to 60s and support update_interval

### DIFF
--- a/components/esp32evse/__init__.py
+++ b/components/esp32evse/__init__.py
@@ -9,7 +9,7 @@ CODEOWNERS = ["@dzurikmiroslav"]
 
 esp32evse_ns = cg.esphome_ns.namespace("esp32evse")
 ESP32EVSEComponent = esp32evse_ns.class_(
-    "ESP32EVSEComponent", cg.Component, uart.UARTDevice
+    "ESP32EVSEComponent", cg.PollingComponent, uart.UARTDevice
 )
 
 CONF_ESP32EVSE_ID = "esp32evse_id"
@@ -17,7 +17,7 @@ CONF_ESP32EVSE_ID = "esp32evse_id"
 CONFIG_SCHEMA = cv.All(
     cv.Schema({cv.GenerateID(): cv.declare_id(ESP32EVSEComponent)})
     .extend(uart.UART_DEVICE_SCHEMA)
-    .extend(cv.COMPONENT_SCHEMA)
+    .extend(cv.polling_component_schema("60000ms"))
 )
 
 FINAL_VALIDATE_SCHEMA = uart.final_validate_device_schema(

--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -46,23 +46,6 @@ void ESP32EVSEComponent::setup() {
 
   });
 
-  if (this->temperature_sensor_ != nullptr) {
-    this->set_interval("temp_poll", 60000, [this]() { this->request_temperature_update(); });
-  }
-  if (this->emeter_power_sensor_ != nullptr) {
-    this->set_interval("emeter_power_poll", 30000, [this]() { this->request_emeter_power_update(); });
-  }
-  if (this->emeter_session_time_sensor_ != nullptr) {
-    this->set_interval("emeter_ses_time_poll", 10000,
-                       [this]() { this->request_emeter_session_time_update(); });
-  }
-  if (this->emeter_charging_time_sensor_ != nullptr) {
-    this->set_interval("emeter_ch_time_poll", 10000,
-                       [this]() { this->request_emeter_charging_time_update(); });
-  }
-  if (this->charging_current_number_ != nullptr) {
-    this->set_interval("chcur_poll", 60000, [this]() { this->request_charging_current_update(); });
-  }
 }
 
 void ESP32EVSEComponent::loop() {
@@ -95,6 +78,27 @@ void ESP32EVSEComponent::loop() {
     if (front.callback)
       front.callback(false);
     this->pending_commands_.pop_front();
+  }
+}
+
+void ESP32EVSEComponent::update() {
+  this->request_state_update();
+  this->request_enable_update();
+
+  if (this->temperature_sensor_ != nullptr) {
+    this->request_temperature_update();
+  }
+  if (this->charging_current_number_ != nullptr) {
+    this->request_charging_current_update();
+  }
+  if (this->emeter_power_sensor_ != nullptr) {
+    this->request_emeter_power_update();
+  }
+  if (this->emeter_session_time_sensor_ != nullptr) {
+    this->request_emeter_session_time_update();
+  }
+  if (this->emeter_charging_time_sensor_ != nullptr) {
+    this->request_emeter_charging_time_update();
   }
 }
 

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -22,11 +22,13 @@ class ESP32EVSEChargingCurrentNumber;
 class ESP32EVSEFastSubscribeButton;
 class ESP32EVSEFastUnsubscribeButton;
 
-class ESP32EVSEComponent : public uart::UARTDevice, public Component {
+class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
  public:
+  ESP32EVSEComponent() : PollingComponent(60000) {}
   void setup() override;
   void loop() override;
   void dump_config() override;
+  void update() override;
 
   void set_state_text_sensor(text_sensor::TextSensor *sensor) { this->state_text_sensor_ = sensor; }
   void set_enable_switch(ESP32EVSEEnableSwitch *sw) { this->enable_switch_ = sw; }


### PR DESCRIPTION
## Summary
- convert ESP32 EVSE component to use PollingComponent with a default 60s interval
- replace multiple custom timers with a unified update() routine that requests all sensor updates
- expose the standard update_interval override via the component schema

## Testing
- python -m compileall components

------
https://chatgpt.com/codex/tasks/task_e_68d3bf17fd44832794a0e3c73b7980bf