### PR TITLE
Expand ESP32 EVSE component sensors and controls

### DIFF
--- a/components/esp32evse/binary_sensor.py
+++ b/components/esp32evse/binary_sensor.py
@@ -1,0 +1,48 @@
+import esphome.codegen as cg
+from esphome.components import binary_sensor
+import esphome.config_validation as cv
+from esphome.const import DEVICE_CLASS_CONNECTIVITY
+
+from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
+
+DEPENDENCIES = ["esp32evse"]
+
+ESP32EVSEPendingAuthorizationBinarySensor = esp32evse_ns.class_(
+    "ESP32EVSEPendingAuthorizationBinarySensor", binary_sensor.BinarySensor
+)
+ESP32EVSEWifiConnectedBinarySensor = esp32evse_ns.class_(
+    "ESP32EVSEWifiConnectedBinarySensor", binary_sensor.BinarySensor
+)
+
+CONF_PENDING_AUTHORIZATION = "pending_authorization"
+CONF_WIFI_CONNECTED = "wifi_connected"
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
+            cv.Optional(CONF_PENDING_AUTHORIZATION): binary_sensor.binary_sensor_schema(
+                icon="mdi:clipboard-clock"
+            ),
+            cv.Optional(CONF_WIFI_CONNECTED): binary_sensor.binary_sensor_schema(
+                device_class=DEVICE_CLASS_CONNECTIVITY,
+                icon="mdi:wifi-check",
+            ),
+        }
+    ),
+    cv.has_at_least_one_key(CONF_PENDING_AUTHORIZATION, CONF_WIFI_CONNECTED),
+)
+
+
+async def to_code(config):
+    parent = await cg.get_variable(config[CONF_ESP32EVSE_ID])
+
+    if pending_config := config.get(CONF_PENDING_AUTHORIZATION):
+        sens = await binary_sensor.new_binary_sensor(pending_config)
+        await cg.register_parented(sens, config[CONF_ESP32EVSE_ID])
+        cg.add(parent.set_pending_authorization_binary_sensor(sens))
+    if wifi_config := config.get(CONF_WIFI_CONNECTED):
+        sens = await binary_sensor.new_binary_sensor(wifi_config)
+        await cg.register_parented(sens, config[CONF_ESP32EVSE_ID])
+        cg.add(parent.set_wifi_connected_binary_sensor(sens))

--- a/components/esp32evse/button.py
+++ b/components/esp32evse/button.py
@@ -12,9 +12,13 @@ ESP32EVSEFastSubscribeButton = esp32evse_ns.class_(
 ESP32EVSEFastUnsubscribeButton = esp32evse_ns.class_(
     "ESP32EVSEFastUnsubscribeButton", button.Button
 )
+ESP32EVSEResetButton = esp32evse_ns.class_("ESP32EVSEResetButton", button.Button)
+ESP32EVSEAuthorizeButton = esp32evse_ns.class_("ESP32EVSEAuthorizeButton", button.Button)
 
 CONF_FAST_SUBSCRIBE = "fast_power_subscribe"
 CONF_FAST_UNSUBSCRIBE = "fast_power_unsubscribe"
+CONF_RESET = "reset"
+CONF_AUTHORIZE = "authorize"
 
 
 CONFIG_SCHEMA = cv.All(
@@ -29,9 +33,22 @@ CONFIG_SCHEMA = cv.All(
                 ESP32EVSEFastUnsubscribeButton,
                 icon="mdi:speedometer-slow",
             ),
+            cv.Optional(CONF_RESET): button.button_schema(
+                ESP32EVSEResetButton,
+                icon="mdi:restart",
+            ),
+            cv.Optional(CONF_AUTHORIZE): button.button_schema(
+                ESP32EVSEAuthorizeButton,
+                icon="mdi:check-decagram",
+            ),
         }
     ),
-    cv.has_at_least_one_key(CONF_FAST_SUBSCRIBE, CONF_FAST_UNSUBSCRIBE),
+    cv.has_at_least_one_key(
+        CONF_FAST_SUBSCRIBE,
+        CONF_FAST_UNSUBSCRIBE,
+        CONF_RESET,
+        CONF_AUTHORIZE,
+    ),
 )
 
 
@@ -46,3 +63,11 @@ async def to_code(config):
         btn = await button.new_button(unsubscribe_config)
         await cg.register_parented(btn, config[CONF_ESP32EVSE_ID])
         cg.add(parent.set_fast_unsubscribe_button(btn))
+    if reset_config := config.get(CONF_RESET):
+        btn = await button.new_button(reset_config)
+        await cg.register_parented(btn, config[CONF_ESP32EVSE_ID])
+        cg.add(parent.set_reset_button(btn))
+    if authorize_config := config.get(CONF_AUTHORIZE):
+        btn = await button.new_button(authorize_config)
+        await cg.register_parented(btn, config[CONF_ESP32EVSE_ID])
+        cg.add(parent.set_authorize_button(btn))

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "esphome/components/binary_sensor/binary_sensor.h"
 #include "esphome/components/button/button.h"
 #include "esphome/components/number/number.h"
 #include "esphome/components/sensor/sensor.h"
@@ -18,9 +19,15 @@ namespace esphome {
 namespace esp32evse {
 
 class ESP32EVSEEnableSwitch;
+class ESP32EVSEAvailableSwitch;
+class ESP32EVSERequestAuthorizationSwitch;
 class ESP32EVSEChargingCurrentNumber;
 class ESP32EVSEFastSubscribeButton;
 class ESP32EVSEFastUnsubscribeButton;
+class ESP32EVSEResetButton;
+class ESP32EVSEAuthorizeButton;
+class ESP32EVSEPendingAuthorizationBinarySensor;
+class ESP32EVSEWifiConnectedBinarySensor;
 
 class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
  public:
@@ -31,11 +38,80 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   void update() override;
 
   void set_state_text_sensor(text_sensor::TextSensor *sensor) { this->state_text_sensor_ = sensor; }
+  void set_chip_text_sensor(text_sensor::TextSensor *sensor) { this->chip_text_sensor_ = sensor; }
+  void set_version_text_sensor(text_sensor::TextSensor *sensor) { this->version_text_sensor_ = sensor; }
+  void set_idf_version_text_sensor(text_sensor::TextSensor *sensor) {
+    this->idf_version_text_sensor_ = sensor;
+  }
+  void set_build_time_text_sensor(text_sensor::TextSensor *sensor) {
+    this->build_time_text_sensor_ = sensor;
+  }
+  void set_device_time_text_sensor(text_sensor::TextSensor *sensor) {
+    this->device_time_text_sensor_ = sensor;
+  }
+  void set_wifi_sta_ssid_text_sensor(text_sensor::TextSensor *sensor) {
+    this->wifi_sta_ssid_text_sensor_ = sensor;
+  }
+  void set_wifi_sta_ip_text_sensor(text_sensor::TextSensor *sensor) {
+    this->wifi_sta_ip_text_sensor_ = sensor;
+  }
+  void set_wifi_sta_mac_text_sensor(text_sensor::TextSensor *sensor) {
+    this->wifi_sta_mac_text_sensor_ = sensor;
+  }
+  void set_device_name_text_sensor(text_sensor::TextSensor *sensor) {
+    this->device_name_text_sensor_ = sensor;
+  }
+
   void set_enable_switch(ESP32EVSEEnableSwitch *sw) { this->enable_switch_ = sw; }
+  void set_available_switch(ESP32EVSEAvailableSwitch *sw) { this->available_switch_ = sw; }
+  void set_request_authorization_switch(ESP32EVSERequestAuthorizationSwitch *sw) {
+    this->request_authorization_switch_ = sw;
+  }
+
   void set_temperature_sensor(sensor::Sensor *sensor) { this->temperature_sensor_ = sensor; }
+  void set_heap_sensor(sensor::Sensor *sensor) { this->heap_sensor_ = sensor; }
+  void set_energy_consumption_sensor(sensor::Sensor *sensor) {
+    this->energy_consumption_sensor_ = sensor;
+  }
+  void set_total_energy_consumption_sensor(sensor::Sensor *sensor) {
+    this->total_energy_consumption_sensor_ = sensor;
+  }
+  void set_voltage_l1_sensor(sensor::Sensor *sensor) { this->voltage_l1_sensor_ = sensor; }
+  void set_voltage_l2_sensor(sensor::Sensor *sensor) { this->voltage_l2_sensor_ = sensor; }
+  void set_voltage_l3_sensor(sensor::Sensor *sensor) { this->voltage_l3_sensor_ = sensor; }
+  void set_current_l1_sensor(sensor::Sensor *sensor) { this->current_l1_sensor_ = sensor; }
+  void set_current_l2_sensor(sensor::Sensor *sensor) { this->current_l2_sensor_ = sensor; }
+  void set_current_l3_sensor(sensor::Sensor *sensor) { this->current_l3_sensor_ = sensor; }
+  void set_wifi_rssi_sensor(sensor::Sensor *sensor) { this->wifi_rssi_sensor_ = sensor; }
+
   void set_charging_current_number(ESP32EVSEChargingCurrentNumber *number) {
     this->charging_current_number_ = number;
   }
+  void set_default_charging_current_number(ESP32EVSEChargingCurrentNumber *number) {
+    this->default_charging_current_number_ = number;
+  }
+  void set_maximum_charging_current_number(ESP32EVSEChargingCurrentNumber *number) {
+    this->maximum_charging_current_number_ = number;
+  }
+  void set_consumption_limit_number(ESP32EVSEChargingCurrentNumber *number) {
+    this->consumption_limit_number_ = number;
+  }
+  void set_default_consumption_limit_number(ESP32EVSEChargingCurrentNumber *number) {
+    this->default_consumption_limit_number_ = number;
+  }
+  void set_charging_time_limit_number(ESP32EVSEChargingCurrentNumber *number) {
+    this->charging_time_limit_number_ = number;
+  }
+  void set_default_charging_time_limit_number(ESP32EVSEChargingCurrentNumber *number) {
+    this->default_charging_time_limit_number_ = number;
+  }
+  void set_under_power_limit_number(ESP32EVSEChargingCurrentNumber *number) {
+    this->under_power_limit_number_ = number;
+  }
+  void set_default_under_power_limit_number(ESP32EVSEChargingCurrentNumber *number) {
+    this->default_under_power_limit_number_ = number;
+  }
+
   void set_emeter_power_sensor(sensor::Sensor *sensor) { this->emeter_power_sensor_ = sensor; }
   void set_emeter_session_time_sensor(sensor::Sensor *sensor) {
     this->emeter_session_time_sensor_ = sensor;
@@ -43,9 +119,19 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   void set_emeter_charging_time_sensor(sensor::Sensor *sensor) {
     this->emeter_charging_time_sensor_ = sensor;
   }
+
   void set_fast_subscribe_button(ESP32EVSEFastSubscribeButton *btn) { this->fast_subscribe_button_ = btn; }
   void set_fast_unsubscribe_button(ESP32EVSEFastUnsubscribeButton *btn) {
     this->fast_unsubscribe_button_ = btn;
+  }
+  void set_reset_button(ESP32EVSEResetButton *btn) { this->reset_button_ = btn; }
+  void set_authorize_button(ESP32EVSEAuthorizeButton *btn) { this->authorize_button_ = btn; }
+
+  void set_pending_authorization_binary_sensor(ESP32EVSEPendingAuthorizationBinarySensor *bs) {
+    this->pending_authorization_binary_sensor_ = bs;
+  }
+  void set_wifi_connected_binary_sensor(ESP32EVSEWifiConnectedBinarySensor *bs) {
+    this->wifi_connected_binary_sensor_ = bs;
   }
 
   void request_state_update();
@@ -55,9 +141,39 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   void request_emeter_power_update();
   void request_emeter_session_time_update();
   void request_emeter_charging_time_update();
+  void request_chip_update();
+  void request_version_update();
+  void request_idf_version_update();
+  void request_build_time_update();
+  void request_device_time_update();
+  void request_wifi_sta_cfg_update();
+  void request_wifi_sta_ip_update();
+  void request_wifi_sta_mac_update();
+  void request_device_name_update();
+  void request_available_update();
+  void request_request_authorization_update();
+  void request_heap_update();
+  void request_energy_consumption_update();
+  void request_total_energy_consumption_update();
+  void request_voltage_update();
+  void request_current_update();
+  void request_wifi_status_update();
+  void request_default_charging_current_update();
+  void request_maximum_charging_current_update();
+  void request_consumption_limit_update();
+  void request_default_consumption_limit_update();
+  void request_charging_time_limit_update();
+  void request_default_charging_time_limit_update();
+  void request_under_power_limit_update();
+  void request_default_under_power_limit_update();
+  void request_pending_authorization_update();
 
   void write_enable_state(bool enabled);
+  void write_available_state(bool available);
+  void write_request_authorization_state(bool request);
   void write_charging_current(float current);
+  void write_number_value(ESP32EVSEChargingCurrentNumber *number, float value);
+
   void subscribe_fast_power_updates();
   void unsubscribe_fast_power_updates();
 
@@ -77,18 +193,85 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   void update_emeter_power_(uint32_t power_w);
   void update_emeter_session_time_(uint32_t time_s);
   void update_emeter_charging_time_(uint32_t time_s);
+  void update_chip_(const std::string &chip);
+  void update_version_(const std::string &version);
+  void update_idf_version_(const std::string &idf_version);
+  void update_build_time_(const std::string &build_time);
+  void update_device_time_(uint32_t timestamp);
+  void update_wifi_sta_cfg_(const std::string &ssid);
+  void update_wifi_sta_ip_(const std::string &ip);
+  void update_wifi_sta_mac_(const std::string &mac);
+  void update_device_name_(const std::string &name);
+  void update_available_(bool available);
+  void update_request_authorization_(bool request);
+  void update_heap_(uint32_t heap_bytes);
+  void update_energy_consumption_(float value);
+  void update_total_energy_consumption_(float value);
+  void update_voltages_(float l1, float l2, float l3);
+  void update_currents_(float l1, float l2, float l3);
+  void update_wifi_status_(bool connected, int rssi);
+  void update_default_charging_current_(uint16_t value_tenths);
+  void update_maximum_charging_current_(uint16_t value_tenths);
+  void update_consumption_limit_(float value);
+  void update_default_consumption_limit_(float value);
+  void update_charging_time_limit_(uint32_t value);
+  void update_default_charging_time_limit_(uint32_t value);
+  void update_under_power_limit_(float value);
+  void update_default_under_power_limit_(float value);
+  void update_pending_authorization_(bool pending);
 
   bool send_command_(const std::string &command, std::function<void(bool)> callback = nullptr);
+  void request_number_update_(ESP32EVSEChargingCurrentNumber *number);
+  void publish_scaled_number_(ESP32EVSEChargingCurrentNumber *number, float raw_value);
 
   text_sensor::TextSensor *state_text_sensor_{nullptr};
+  text_sensor::TextSensor *chip_text_sensor_{nullptr};
+  text_sensor::TextSensor *version_text_sensor_{nullptr};
+  text_sensor::TextSensor *idf_version_text_sensor_{nullptr};
+  text_sensor::TextSensor *build_time_text_sensor_{nullptr};
+  text_sensor::TextSensor *device_time_text_sensor_{nullptr};
+  text_sensor::TextSensor *wifi_sta_ssid_text_sensor_{nullptr};
+  text_sensor::TextSensor *wifi_sta_ip_text_sensor_{nullptr};
+  text_sensor::TextSensor *wifi_sta_mac_text_sensor_{nullptr};
+  text_sensor::TextSensor *device_name_text_sensor_{nullptr};
+
   ESP32EVSEEnableSwitch *enable_switch_{nullptr};
+  ESP32EVSEAvailableSwitch *available_switch_{nullptr};
+  ESP32EVSERequestAuthorizationSwitch *request_authorization_switch_{nullptr};
+
   sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *heap_sensor_{nullptr};
+  sensor::Sensor *energy_consumption_sensor_{nullptr};
+  sensor::Sensor *total_energy_consumption_sensor_{nullptr};
+  sensor::Sensor *voltage_l1_sensor_{nullptr};
+  sensor::Sensor *voltage_l2_sensor_{nullptr};
+  sensor::Sensor *voltage_l3_sensor_{nullptr};
+  sensor::Sensor *current_l1_sensor_{nullptr};
+  sensor::Sensor *current_l2_sensor_{nullptr};
+  sensor::Sensor *current_l3_sensor_{nullptr};
+  sensor::Sensor *wifi_rssi_sensor_{nullptr};
+
   ESP32EVSEChargingCurrentNumber *charging_current_number_{nullptr};
+  ESP32EVSEChargingCurrentNumber *default_charging_current_number_{nullptr};
+  ESP32EVSEChargingCurrentNumber *maximum_charging_current_number_{nullptr};
+  ESP32EVSEChargingCurrentNumber *consumption_limit_number_{nullptr};
+  ESP32EVSEChargingCurrentNumber *default_consumption_limit_number_{nullptr};
+  ESP32EVSEChargingCurrentNumber *charging_time_limit_number_{nullptr};
+  ESP32EVSEChargingCurrentNumber *default_charging_time_limit_number_{nullptr};
+  ESP32EVSEChargingCurrentNumber *under_power_limit_number_{nullptr};
+  ESP32EVSEChargingCurrentNumber *default_under_power_limit_number_{nullptr};
+
   sensor::Sensor *emeter_power_sensor_{nullptr};
   sensor::Sensor *emeter_session_time_sensor_{nullptr};
   sensor::Sensor *emeter_charging_time_sensor_{nullptr};
+
   ESP32EVSEFastSubscribeButton *fast_subscribe_button_{nullptr};
   ESP32EVSEFastUnsubscribeButton *fast_unsubscribe_button_{nullptr};
+  ESP32EVSEResetButton *reset_button_{nullptr};
+  ESP32EVSEAuthorizeButton *authorize_button_{nullptr};
+
+  ESP32EVSEPendingAuthorizationBinarySensor *pending_authorization_binary_sensor_{nullptr};
+  ESP32EVSEWifiConnectedBinarySensor *wifi_connected_binary_sensor_{nullptr};
 
   std::string read_buffer_;
   std::deque<PendingCommand> pending_commands_;
@@ -99,12 +282,30 @@ class ESP32EVSEEnableSwitch : public switch_::Switch, public Parented<ESP32EVSEC
   void write_state(bool state) override;
 };
 
+class ESP32EVSEAvailableSwitch : public switch_::Switch, public Parented<ESP32EVSEComponent> {
+ protected:
+  void write_state(bool state) override;
+};
+
+class ESP32EVSERequestAuthorizationSwitch
+    : public switch_::Switch, public Parented<ESP32EVSEComponent> {
+ protected:
+  void write_state(bool state) override;
+};
+
 class ESP32EVSEChargingCurrentNumber : public number::Number, public Parented<ESP32EVSEComponent> {
  public:
   ESP32EVSEChargingCurrentNumber();
+  void set_command(const std::string &command) { this->command_ = command; }
+  void set_multiplier(float multiplier) { this->multiplier_ = multiplier; }
+  const std::string &get_command() const { return this->command_; }
+  float get_multiplier() const { return this->multiplier_; }
 
  protected:
   void control(float value) override;
+
+  std::string command_{"AT+CHCUR"};
+  float multiplier_{10.0f};
 };
 
 class ESP32EVSEFastSubscribeButton : public button::Button, public Parented<ESP32EVSEComponent> {
@@ -116,6 +317,23 @@ class ESP32EVSEFastUnsubscribeButton : public button::Button, public Parented<ES
  protected:
   void press_action() override;
 };
+
+class ESP32EVSEResetButton : public button::Button, public Parented<ESP32EVSEComponent> {
+ protected:
+  void press_action() override;
+};
+
+class ESP32EVSEAuthorizeButton : public button::Button, public Parented<ESP32EVSEComponent> {
+ protected:
+  void press_action() override;
+};
+
+class ESP32EVSEPendingAuthorizationBinarySensor
+    : public binary_sensor::BinarySensor,
+      public Parented<ESP32EVSEComponent> {};
+
+class ESP32EVSEWifiConnectedBinarySensor : public binary_sensor::BinarySensor,
+                                           public Parented<ESP32EVSEComponent> {};
 
 }  // namespace esp32evse
 }  // namespace esphome

--- a/components/esp32evse/number.py
+++ b/components/esp32evse/number.py
@@ -4,7 +4,14 @@ import esphome.codegen as cg
 from esphome.components import number
 import esphome.config_validation as cv
 
-from esphome.const import CONF_MAX_VALUE, CONF_MIN_VALUE, CONF_STEP, UNIT_AMPERE
+from esphome.const import (
+    CONF_MAX_VALUE,
+    CONF_MIN_VALUE,
+    CONF_STEP,
+    UNIT_AMPERE,
+    UNIT_SECOND,
+    UNIT_WATT,
+)
 
 from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
 
@@ -15,48 +22,182 @@ ESP32EVSEChargingCurrentNumber = esp32evse_ns.class_(
 )
 
 CONF_CHARGING_CURRENT = "charging_current"
+CONF_DEFAULT_CHARGING_CURRENT = "default_charging_current"
+CONF_MAXIMUM_CHARGING_CURRENT = "maximum_charging_current"
+CONF_CONSUMPTION_LIMIT = "consumption_limit"
+CONF_DEFAULT_CONSUMPTION_LIMIT = "default_consumption_limit"
+CONF_CHARGING_TIME_LIMIT = "charging_time_limit"
+CONF_DEFAULT_CHARGING_TIME_LIMIT = "default_charging_time_limit"
+CONF_UNDER_POWER_LIMIT = "under_power_limit"
+CONF_DEFAULT_UNDER_POWER_LIMIT = "default_under_power_limit"
+CONF_MULTIPLIER = "multiplier"
+
+_NUMBER_SCHEMA_SUPPORTS_LIMITS = "min_value" in inspect.signature(  # pragma: no branch
+    number.number_schema
+).parameters
 
 
-_NUMBER_SCHEMA_KWARGS = {
-    "icon": "mdi:current-ac",
-    "unit_of_measurement": UNIT_AMPERE,
-}
-
-if "min_value" in inspect.signature(number.number_schema).parameters:
-    _NUMBER_SCHEMA_KWARGS.update(
+def _build_number_schema(icon, unit, default_min, default_max, default_step, default_multiplier):
+    kwargs = {"icon": icon}
+    if unit is not None:
+        kwargs["unit_of_measurement"] = unit
+    if _NUMBER_SCHEMA_SUPPORTS_LIMITS:
+        kwargs.update(
+            {
+                "min_value": default_min,
+                "max_value": default_max,
+                "step": default_step,
+            }
+        )
+    base = number.number_schema(ESP32EVSEChargingCurrentNumber, **kwargs)
+    return base.extend(
         {
-            "min_value": 6.0,
-            "max_value": 63.0,
-            "step": 0.1,
+            cv.Optional(CONF_MIN_VALUE, default=default_min): cv.float_,
+            cv.Optional(CONF_MAX_VALUE, default=default_max): cv.float_,
+            cv.Optional(CONF_STEP, default=default_step): cv.positive_float,
+            cv.Optional(CONF_MULTIPLIER, default=default_multiplier): cv.positive_float,
         }
     )
 
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
-        cv.Required(CONF_CHARGING_CURRENT): number.number_schema(
-            ESP32EVSEChargingCurrentNumber,
-            **_NUMBER_SCHEMA_KWARGS,
-        ).extend(
-            {
-                cv.Optional(CONF_MIN_VALUE, default=6.0): cv.float_,
-                cv.Optional(CONF_MAX_VALUE, default=63.0): cv.float_,
-                cv.Optional(CONF_STEP, default=0.1): cv.positive_float,
-            }
+_NUMBER_TYPES = {
+    CONF_CHARGING_CURRENT: {
+        "schema": _build_number_schema(
+            icon="mdi:current-ac",
+            unit=UNIT_AMPERE,
+            default_min=6.0,
+            default_max=63.0,
+            default_step=0.1,
+            default_multiplier=10.0,
         ),
-    }
+        "command": "AT+CHCUR",
+        "setter": "set_charging_current_number",
+    },
+    CONF_DEFAULT_CHARGING_CURRENT: {
+        "schema": _build_number_schema(
+            icon="mdi:current-ac",
+            unit=UNIT_AMPERE,
+            default_min=6.0,
+            default_max=63.0,
+            default_step=0.1,
+            default_multiplier=10.0,
+        ),
+        "command": "AT+DEFCHCUR",
+        "setter": "set_default_charging_current_number",
+    },
+    CONF_MAXIMUM_CHARGING_CURRENT: {
+        "schema": _build_number_schema(
+            icon="mdi:current-ac",
+            unit=UNIT_AMPERE,
+            default_min=6.0,
+            default_max=63.0,
+            default_step=0.1,
+            default_multiplier=10.0,
+        ),
+        "command": "AT+MAXCHCUR",
+        "setter": "set_maximum_charging_current_number",
+    },
+    CONF_CONSUMPTION_LIMIT: {
+        "schema": _build_number_schema(
+            icon="mdi:gauge",
+            unit=UNIT_WATT,
+            default_min=0.0,
+            default_max=100000.0,
+            default_step=10.0,
+            default_multiplier=1.0,
+        ),
+        "command": "AT+CONSUMLIM",
+        "setter": "set_consumption_limit_number",
+    },
+    CONF_DEFAULT_CONSUMPTION_LIMIT: {
+        "schema": _build_number_schema(
+            icon="mdi:gauge",
+            unit=UNIT_WATT,
+            default_min=0.0,
+            default_max=100000.0,
+            default_step=10.0,
+            default_multiplier=1.0,
+        ),
+        "command": "AT+DEFCONSUMLIM",
+        "setter": "set_default_consumption_limit_number",
+    },
+    CONF_CHARGING_TIME_LIMIT: {
+        "schema": _build_number_schema(
+            icon="mdi:timer-outline",
+            unit=UNIT_SECOND,
+            default_min=0.0,
+            default_max=86400.0,
+            default_step=60.0,
+            default_multiplier=1.0,
+        ),
+        "command": "AT+CHTIMELIM",
+        "setter": "set_charging_time_limit_number",
+    },
+    CONF_DEFAULT_CHARGING_TIME_LIMIT: {
+        "schema": _build_number_schema(
+            icon="mdi:timer-outline",
+            unit=UNIT_SECOND,
+            default_min=0.0,
+            default_max=86400.0,
+            default_step=60.0,
+            default_multiplier=1.0,
+        ),
+        "command": "AT+DEFCHTIMELIM",
+        "setter": "set_default_charging_time_limit_number",
+    },
+    CONF_UNDER_POWER_LIMIT: {
+        "schema": _build_number_schema(
+            icon="mdi:flash-outline",
+            unit=UNIT_WATT,
+            default_min=0.0,
+            default_max=100000.0,
+            default_step=10.0,
+            default_multiplier=1.0,
+        ),
+        "command": "AT+UNDERPOWERLIM",
+        "setter": "set_under_power_limit_number",
+    },
+    CONF_DEFAULT_UNDER_POWER_LIMIT: {
+        "schema": _build_number_schema(
+            icon="mdi:flash-outline",
+            unit=UNIT_WATT,
+            default_min=0.0,
+            default_max=100000.0,
+            default_step=10.0,
+            default_multiplier=1.0,
+        ),
+        "command": "AT+DEFUNDERPOWERLIM",
+        "setter": "set_default_under_power_limit_number",
+    },
+}
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
+            **{
+                cv.Optional(key): meta["schema"] for key, meta in _NUMBER_TYPES.items()
+            },
+        }
+    ),
+    cv.has_at_least_one_key(*_NUMBER_TYPES.keys()),
 )
 
 
 async def to_code(config):
     parent = await cg.get_variable(config[CONF_ESP32EVSE_ID])
-    charging_current_cfg = config[CONF_CHARGING_CURRENT]
-    num = await number.new_number(
-        charging_current_cfg,
-        min_value=charging_current_cfg[CONF_MIN_VALUE],
-        max_value=charging_current_cfg[CONF_MAX_VALUE],
-        step=charging_current_cfg[CONF_STEP],
-    )
-    await cg.register_parented(num, config[CONF_ESP32EVSE_ID])
-    cg.add(parent.set_charging_current_number(num))
+    for key, meta in _NUMBER_TYPES.items():
+        if key not in config:
+            continue
+        number_config = config[key]
+        num = await number.new_number(
+            number_config,
+            min_value=number_config[CONF_MIN_VALUE],
+            max_value=number_config[CONF_MAX_VALUE],
+            step=number_config[CONF_STEP],
+        )
+        await cg.register_parented(num, config[CONF_ESP32EVSE_ID])
+        cg.add(num.set_command(meta["command"]))
+        cg.add(num.set_multiplier(number_config[CONF_MULTIPLIER]))
+        cg.add(getattr(parent, meta["setter"])(num))

--- a/components/esp32evse/sensor.py
+++ b/components/esp32evse/sensor.py
@@ -2,14 +2,22 @@ import esphome.codegen as cg
 from esphome.components import sensor
 import esphome.config_validation as cv
 from esphome.const import (
+    DEVICE_CLASS_CURRENT,
     DEVICE_CLASS_POWER,
+    DEVICE_CLASS_SIGNAL_STRENGTH,
     DEVICE_CLASS_TEMPERATURE,
+    DEVICE_CLASS_VOLTAGE,
     ICON_FLASH,
     ICON_THERMOMETER,
     ICON_TIMER,
     STATE_CLASS_MEASUREMENT,
+    UNIT_AMPERE,
+    UNIT_BYTE,
     UNIT_CELSIUS,
+    UNIT_DECIBEL_MILLIWATT,
     UNIT_SECOND,
+    UNIT_VOLT,
+    UNIT_WATT_HOUR,
 )
 
 from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent
@@ -20,6 +28,16 @@ CONF_TEMPERATURE = "temperature"
 CONF_EMETER_POWER = "emeter_power"
 CONF_EMETER_SESSION_TIME = "emeter_session_time"
 CONF_EMETER_CHARGING_TIME = "emeter_charging_time"
+CONF_HEAP = "heap"
+CONF_ENERGY_CONSUMPTION = "energy_consumption"
+CONF_TOTAL_ENERGY_CONSUMPTION = "total_energy_consumption"
+CONF_VOLTAGE_L1 = "voltage_l1"
+CONF_VOLTAGE_L2 = "voltage_l2"
+CONF_VOLTAGE_L3 = "voltage_l3"
+CONF_CURRENT_L1 = "current_l1"
+CONF_CURRENT_L2 = "current_l2"
+CONF_CURRENT_L3 = "current_l3"
+CONF_WIFI_RSSI = "wifi_rssi"
 
 
 CONFIG_SCHEMA = cv.All(
@@ -49,6 +67,63 @@ CONFIG_SCHEMA = cv.All(
                 icon=ICON_TIMER,
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
+            cv.Optional(CONF_HEAP): sensor.sensor_schema(
+                unit_of_measurement=UNIT_BYTE,
+                icon="mdi:memory",
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_ENERGY_CONSUMPTION): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT_HOUR,
+                icon="mdi:counter",
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_TOTAL_ENERGY_CONSUMPTION): sensor.sensor_schema(
+                unit_of_measurement=UNIT_WATT_HOUR,
+                icon="mdi:counter",
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_VOLTAGE_L1): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT,
+                icon="mdi:alpha-v-circle",
+                device_class=DEVICE_CLASS_VOLTAGE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_VOLTAGE_L2): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT,
+                icon="mdi:alpha-v-circle",
+                device_class=DEVICE_CLASS_VOLTAGE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_VOLTAGE_L3): sensor.sensor_schema(
+                unit_of_measurement=UNIT_VOLT,
+                icon="mdi:alpha-v-circle",
+                device_class=DEVICE_CLASS_VOLTAGE,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_CURRENT_L1): sensor.sensor_schema(
+                unit_of_measurement=UNIT_AMPERE,
+                icon="mdi:alpha-a-circle",
+                device_class=DEVICE_CLASS_CURRENT,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_CURRENT_L2): sensor.sensor_schema(
+                unit_of_measurement=UNIT_AMPERE,
+                icon="mdi:alpha-a-circle",
+                device_class=DEVICE_CLASS_CURRENT,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_CURRENT_L3): sensor.sensor_schema(
+                unit_of_measurement=UNIT_AMPERE,
+                icon="mdi:alpha-a-circle",
+                device_class=DEVICE_CLASS_CURRENT,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_WIFI_RSSI): sensor.sensor_schema(
+                unit_of_measurement=UNIT_DECIBEL_MILLIWATT,
+                icon="mdi:wifi-strength-2",
+                device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
+                state_class=STATE_CLASS_MEASUREMENT,
+            ),
         }
     ),
     cv.has_at_least_one_key(
@@ -56,6 +131,16 @@ CONFIG_SCHEMA = cv.All(
         CONF_EMETER_POWER,
         CONF_EMETER_SESSION_TIME,
         CONF_EMETER_CHARGING_TIME,
+        CONF_HEAP,
+        CONF_ENERGY_CONSUMPTION,
+        CONF_TOTAL_ENERGY_CONSUMPTION,
+        CONF_VOLTAGE_L1,
+        CONF_VOLTAGE_L2,
+        CONF_VOLTAGE_L3,
+        CONF_CURRENT_L1,
+        CONF_CURRENT_L2,
+        CONF_CURRENT_L3,
+        CONF_WIFI_RSSI,
     ),
 )
 
@@ -75,3 +160,33 @@ async def to_code(config):
     if charging_config := config.get(CONF_EMETER_CHARGING_TIME):
         sens = await sensor.new_sensor(charging_config)
         cg.add(parent.set_emeter_charging_time_sensor(sens))
+    if heap_config := config.get(CONF_HEAP):
+        sens = await sensor.new_sensor(heap_config)
+        cg.add(parent.set_heap_sensor(sens))
+    if energy_config := config.get(CONF_ENERGY_CONSUMPTION):
+        sens = await sensor.new_sensor(energy_config)
+        cg.add(parent.set_energy_consumption_sensor(sens))
+    if total_energy_config := config.get(CONF_TOTAL_ENERGY_CONSUMPTION):
+        sens = await sensor.new_sensor(total_energy_config)
+        cg.add(parent.set_total_energy_consumption_sensor(sens))
+    if voltage_l1_config := config.get(CONF_VOLTAGE_L1):
+        sens = await sensor.new_sensor(voltage_l1_config)
+        cg.add(parent.set_voltage_l1_sensor(sens))
+    if voltage_l2_config := config.get(CONF_VOLTAGE_L2):
+        sens = await sensor.new_sensor(voltage_l2_config)
+        cg.add(parent.set_voltage_l2_sensor(sens))
+    if voltage_l3_config := config.get(CONF_VOLTAGE_L3):
+        sens = await sensor.new_sensor(voltage_l3_config)
+        cg.add(parent.set_voltage_l3_sensor(sens))
+    if current_l1_config := config.get(CONF_CURRENT_L1):
+        sens = await sensor.new_sensor(current_l1_config)
+        cg.add(parent.set_current_l1_sensor(sens))
+    if current_l2_config := config.get(CONF_CURRENT_L2):
+        sens = await sensor.new_sensor(current_l2_config)
+        cg.add(parent.set_current_l2_sensor(sens))
+    if current_l3_config := config.get(CONF_CURRENT_L3):
+        sens = await sensor.new_sensor(current_l3_config)
+        cg.add(parent.set_current_l3_sensor(sens))
+    if wifi_rssi_config := config.get(CONF_WIFI_RSSI):
+        sens = await sensor.new_sensor(wifi_rssi_config)
+        cg.add(parent.set_wifi_rssi_sensor(sens))

--- a/components/esp32evse/switch.py
+++ b/components/esp32evse/switch.py
@@ -7,25 +7,50 @@ from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
 DEPENDENCIES = ["esp32evse"]
 
 ESP32EVSEEnableSwitch = esp32evse_ns.class_("ESP32EVSEEnableSwitch", switch.Switch)
+ESP32EVSEAvailableSwitch = esp32evse_ns.class_("ESP32EVSEAvailableSwitch", switch.Switch)
+ESP32EVSERequestAuthorizationSwitch = esp32evse_ns.class_(
+    "ESP32EVSERequestAuthorizationSwitch", switch.Switch
+)
 
 CONF_ENABLE = "enable"
+CONF_AVAILABLE = "available"
+CONF_REQUEST_AUTHORIZATION = "request_authorization"
 
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
-        cv.Required(CONF_ENABLE): switch.switch_schema(
-            ESP32EVSEEnableSwitch,
-            icon="mdi:toggle-switch",
-        ),
-    }
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
+            cv.Optional(CONF_ENABLE): switch.switch_schema(
+                ESP32EVSEEnableSwitch,
+                icon="mdi:toggle-switch",
+            ),
+            cv.Optional(CONF_AVAILABLE): switch.switch_schema(
+                ESP32EVSEAvailableSwitch,
+                icon="mdi:check-network",
+            ),
+            cv.Optional(CONF_REQUEST_AUTHORIZATION): switch.switch_schema(
+                ESP32EVSERequestAuthorizationSwitch,
+                icon="mdi:hand-back-right",
+            ),
+        }
+    ),
+    cv.has_at_least_one_key(CONF_ENABLE, CONF_AVAILABLE, CONF_REQUEST_AUTHORIZATION),
 )
 
 
 async def to_code(config):
     parent = await cg.get_variable(config[CONF_ESP32EVSE_ID])
 
-    enable_config = config[CONF_ENABLE]
-    sw = await switch.new_switch(enable_config)
-    await cg.register_parented(sw, config[CONF_ESP32EVSE_ID])
-    cg.add(parent.set_enable_switch(sw))
+    if enable_config := config.get(CONF_ENABLE):
+        sw = await switch.new_switch(enable_config)
+        await cg.register_parented(sw, config[CONF_ESP32EVSE_ID])
+        cg.add(parent.set_enable_switch(sw))
+    if available_config := config.get(CONF_AVAILABLE):
+        sw = await switch.new_switch(available_config)
+        await cg.register_parented(sw, config[CONF_ESP32EVSE_ID])
+        cg.add(parent.set_available_switch(sw))
+    if req_auth_config := config.get(CONF_REQUEST_AUTHORIZATION):
+        sw = await switch.new_switch(req_auth_config)
+        await cg.register_parented(sw, config[CONF_ESP32EVSE_ID])
+        cg.add(parent.set_request_authorization_switch(sw))

--- a/components/esp32evse/text_sensor.py
+++ b/components/esp32evse/text_sensor.py
@@ -7,19 +7,78 @@ from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent
 DEPENDENCIES = ["esp32evse"]
 
 CONF_STATE = "state"
+CONF_CHIP = "chip"
+CONF_VERSION = "version"
+CONF_IDF_VERSION = "idf_version"
+CONF_BUILD_TIME = "build_time"
+CONF_DEVICE_TIME = "device_time"
+CONF_WIFI_STA_SSID = "wifi_sta_ssid"
+CONF_WIFI_STA_IP = "wifi_sta_ip"
+CONF_WIFI_STA_MAC = "wifi_sta_mac"
+CONF_DEVICE_NAME = "device_name"
 
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
-        cv.Required(CONF_STATE): text_sensor.text_sensor_schema(icon="mdi:ev-station"),
-    }
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
+            cv.Optional(CONF_STATE): text_sensor.text_sensor_schema(icon="mdi:ev-station"),
+            cv.Optional(CONF_CHIP): text_sensor.text_sensor_schema(icon="mdi:chip"),
+            cv.Optional(CONF_VERSION): text_sensor.text_sensor_schema(icon="mdi:tag"),
+            cv.Optional(CONF_IDF_VERSION): text_sensor.text_sensor_schema(icon="mdi:alpha-i-circle"),
+            cv.Optional(CONF_BUILD_TIME): text_sensor.text_sensor_schema(icon="mdi:clock-outline"),
+            cv.Optional(CONF_DEVICE_TIME): text_sensor.text_sensor_schema(icon="mdi:clock"),
+            cv.Optional(CONF_WIFI_STA_SSID): text_sensor.text_sensor_schema(icon="mdi:wifi"),
+            cv.Optional(CONF_WIFI_STA_IP): text_sensor.text_sensor_schema(icon="mdi:ip"),
+            cv.Optional(CONF_WIFI_STA_MAC): text_sensor.text_sensor_schema(icon="mdi:lan"),
+            cv.Optional(CONF_DEVICE_NAME): text_sensor.text_sensor_schema(icon="mdi:rename-box"),
+        }
+    ),
+    cv.has_at_least_one_key(
+        CONF_STATE,
+        CONF_CHIP,
+        CONF_VERSION,
+        CONF_IDF_VERSION,
+        CONF_BUILD_TIME,
+        CONF_DEVICE_TIME,
+        CONF_WIFI_STA_SSID,
+        CONF_WIFI_STA_IP,
+        CONF_WIFI_STA_MAC,
+        CONF_DEVICE_NAME,
+    ),
 )
 
 
 async def to_code(config):
     parent = await cg.get_variable(config[CONF_ESP32EVSE_ID])
 
-    state_config = config[CONF_STATE]
-    sens = await text_sensor.new_text_sensor(state_config)
-    cg.add(parent.set_state_text_sensor(sens))
+    if state_config := config.get(CONF_STATE):
+        sens = await text_sensor.new_text_sensor(state_config)
+        cg.add(parent.set_state_text_sensor(sens))
+    if chip_config := config.get(CONF_CHIP):
+        sens = await text_sensor.new_text_sensor(chip_config)
+        cg.add(parent.set_chip_text_sensor(sens))
+    if version_config := config.get(CONF_VERSION):
+        sens = await text_sensor.new_text_sensor(version_config)
+        cg.add(parent.set_version_text_sensor(sens))
+    if idf_version_config := config.get(CONF_IDF_VERSION):
+        sens = await text_sensor.new_text_sensor(idf_version_config)
+        cg.add(parent.set_idf_version_text_sensor(sens))
+    if build_time_config := config.get(CONF_BUILD_TIME):
+        sens = await text_sensor.new_text_sensor(build_time_config)
+        cg.add(parent.set_build_time_text_sensor(sens))
+    if device_time_config := config.get(CONF_DEVICE_TIME):
+        sens = await text_sensor.new_text_sensor(device_time_config)
+        cg.add(parent.set_device_time_text_sensor(sens))
+    if wifi_ssid_config := config.get(CONF_WIFI_STA_SSID):
+        sens = await text_sensor.new_text_sensor(wifi_ssid_config)
+        cg.add(parent.set_wifi_sta_ssid_text_sensor(sens))
+    if wifi_ip_config := config.get(CONF_WIFI_STA_IP):
+        sens = await text_sensor.new_text_sensor(wifi_ip_config)
+        cg.add(parent.set_wifi_sta_ip_text_sensor(sens))
+    if wifi_mac_config := config.get(CONF_WIFI_STA_MAC):
+        sens = await text_sensor.new_text_sensor(wifi_mac_config)
+        cg.add(parent.set_wifi_sta_mac_text_sensor(sens))
+    if device_name_config := config.get(CONF_DEVICE_NAME):
+        sens = await text_sensor.new_text_sensor(device_name_config)
+        cg.add(parent.set_device_name_text_sensor(sens))


### PR DESCRIPTION
## Summary
- extend the ESP32 EVSE C++ component to handle additional status queries, device metadata, Wi-Fi telemetry, and new control commands
- expose configuration hooks for new buttons, switches, sensors, binary sensors, and scaled numbers in the ESPHome integration
- add configuration schema for pending authorization and Wi-Fi connectivity binary sensors

## Testing
- `python -m compileall components/esp32evse`


------
https://chatgpt.com/codex/tasks/task_e_68d3c75bb6b48327b2df61795c835196