### PR TITLE
Fix heap sensor unit for latest ESPHome

### DIFF
--- a/components/esp32evse/sensor.py
+++ b/components/esp32evse/sensor.py
@@ -12,7 +12,6 @@ from esphome.const import (
     ICON_TIMER,
     STATE_CLASS_MEASUREMENT,
     UNIT_AMPERE,
-    UNIT_BYTE,
     UNIT_CELSIUS,
     UNIT_DECIBEL_MILLIWATT,
     UNIT_SECOND,
@@ -68,7 +67,7 @@ CONFIG_SCHEMA = cv.All(
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_HEAP): sensor.sensor_schema(
-                unit_of_measurement=UNIT_BYTE,
+                unit_of_measurement="B",
                 icon="mdi:memory",
                 state_class=STATE_CLASS_MEASUREMENT,
             ),


### PR DESCRIPTION
## Summary
- replace the deprecated UNIT_BYTE constant with a string literal
- keep the heap sensor compatible with newer ESPHome releases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3cee585c08327a5de440c14a824a7