### PR TITLE
Handle renamed energy unit constant in ESP32EVSE sensor

### DIFF
--- a/components/esp32evse/sensor.py
+++ b/components/esp32evse/sensor.py
@@ -16,8 +16,12 @@ from esphome.const import (
     UNIT_DECIBEL_MILLIWATT,
     UNIT_SECOND,
     UNIT_VOLT,
-    UNIT_WATT_HOUR,
 )
+
+try:
+    from esphome.const import UNIT_WATT_HOUR
+except ImportError:
+    from esphome.const import UNIT_WATT_HOURS as UNIT_WATT_HOUR
 
 from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent
 


### PR DESCRIPTION
## Summary
- import the renamed UNIT_WATT_HOURS constant when UNIT_WATT_HOUR is unavailable to keep energy sensors working on newer ESPHome releases

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3cf86a2a883279363fe71905c3747