### PR TITLE
Expose command helpers for button actions

### DIFF
--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -344,6 +344,10 @@ void ESP32EVSEComponent::unsubscribe_fast_power_updates() {
   this->send_command_("AT+UNSUB=\"+EMETERPOWER\"");
 }
 
+void ESP32EVSEComponent::send_reset_command() { this->send_command_("AT+RST"); }
+
+void ESP32EVSEComponent::send_authorize_command() { this->send_command_("AT+AUTH"); }
+
 bool ESP32EVSEComponent::send_command_(const std::string &command, std::function<void(bool)> callback) {
   ESP_LOGV(TAG, "Sending command: %s", command.c_str());
   this->write_str(command.c_str());
@@ -859,13 +863,13 @@ void ESP32EVSEFastUnsubscribeButton::press_action() {
 void ESP32EVSEResetButton::press_action() {
   if (this->parent_ == nullptr)
     return;
-  this->parent_->send_command_("AT+RST");
+  this->parent_->send_reset_command();
 }
 
 void ESP32EVSEAuthorizeButton::press_action() {
   if (this->parent_ == nullptr)
     return;
-  this->parent_->send_command_("AT+AUTH");
+  this->parent_->send_authorize_command();
 }
 
 }  // namespace esp32evse

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -176,6 +176,8 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
 
   void subscribe_fast_power_updates();
   void unsubscribe_fast_power_updates();
+  void send_reset_command();
+  void send_authorize_command();
 
  protected:
   struct PendingCommand {


### PR DESCRIPTION
## Summary
- add public wrapper methods on `ESP32EVSEComponent` for reset and authorize commands
- update button handlers to call the new public helpers instead of the protected `send_command_`

## Testing
- `pio run` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d1d605ac8327b01fc8dcfc9c738b