### PR TITLE
Fix ESP32EVSE binary sensor class usage

### DIFF
--- a/components/esp32evse/binary_sensor.py
+++ b/components/esp32evse/binary_sensor.py
@@ -23,9 +23,11 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
             cv.Optional(CONF_PENDING_AUTHORIZATION): binary_sensor.binary_sensor_schema(
-                icon="mdi:clipboard-clock"
+                ESP32EVSEPendingAuthorizationBinarySensor,
+                icon="mdi:clipboard-clock",
             ),
             cv.Optional(CONF_WIFI_CONNECTED): binary_sensor.binary_sensor_schema(
+                ESP32EVSEWifiConnectedBinarySensor,
                 device_class=DEVICE_CLASS_CONNECTIVITY,
                 icon="mdi:wifi-check",
             ),


### PR DESCRIPTION
## Summary
- ensure the ESP32EVSE binary sensor schemas instantiate the component-specific subclasses so generated C++ can call set_parent

## Testing
- esphome compile esphome.yaml *(fails: TypeError: 'int' object is not subscriptable while iterating configs)*

------
https://chatgpt.com/codex/tasks/task_e_68d3d765aa608327add5a1c8d5b45917