### PR TITLE
Queue EVSE commands to avoid overwhelming hardware

### DIFF
--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -183,11 +183,13 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   struct PendingCommand {
     std::string command;
     std::function<void(bool)> callback;
-    uint32_t start_time;
+    uint32_t start_time{0};
+    bool sent{false};
   };
 
   void process_line_(const std::string &line);
   void handle_ack_(bool success);
+  void process_next_command_();
   void update_state_(uint8_t state);
   void update_enable_(bool enable);
   void update_temperature_(int count, int32_t high, int32_t low);


### PR DESCRIPTION
## Summary
- queue EVSE serial commands so only one is transmitted at a time
- resend the next queued command after acknowledgements or timeouts to avoid overwhelming the EVSE

## Testing
- python -m compileall components

------
https://chatgpt.com/codex/tasks/task_e_68d3d929866c8327b181e3ff07b62b04