### PR TITLE
Sanitize build time text sensor output

### DIFF
--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -670,7 +670,12 @@ void ESP32EVSEComponent::update_idf_version_(const std::string &idf_version) {
 
 void ESP32EVSEComponent::update_build_time_(const std::string &build_time) {
   if (this->build_time_text_sensor_ != nullptr) {
-    this->build_time_text_sensor_->publish_state(build_time);
+    std::string sanitized = build_time;
+    size_t pos = 0;
+    while ((pos = sanitized.find('"', pos)) != std::string::npos) {
+      sanitized.erase(pos, 1);
+    }
+    this->build_time_text_sensor_->publish_state(sanitized);
   }
 }
 


### PR DESCRIPTION
## Summary
- strip embedded double quotes from the build time string before publishing it
- remove the extra `<algorithm>` include by switching to simple string erasure logic

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3db1e7400832794a59ed3bc7599fa