### PR TITLE
Set entity categories for diagnostics and config entities

### DIFF
--- a/components/esp32evse/binary_sensor.py
+++ b/components/esp32evse/binary_sensor.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import binary_sensor
 import esphome.config_validation as cv
-from esphome.const import DEVICE_CLASS_CONNECTIVITY
+from esphome.const import DEVICE_CLASS_CONNECTIVITY, EntityCategory
 
 from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
 
@@ -30,6 +30,7 @@ CONFIG_SCHEMA = cv.All(
                 ESP32EVSEWifiConnectedBinarySensor,
                 device_class=DEVICE_CLASS_CONNECTIVITY,
                 icon="mdi:wifi-check",
+                entity_category=EntityCategory.DIAGNOSTIC,
             ),
         }
     ),

--- a/components/esp32evse/button.py
+++ b/components/esp32evse/button.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import button
 import esphome.config_validation as cv
+from esphome.const import EntityCategory
 
 from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
 
@@ -36,6 +37,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_RESET): button.button_schema(
                 ESP32EVSEResetButton,
                 icon="mdi:restart",
+                entity_category=EntityCategory.DIAGNOSTIC,
             ),
             cv.Optional(CONF_AUTHORIZE): button.button_schema(
                 ESP32EVSEAuthorizeButton,

--- a/components/esp32evse/number.py
+++ b/components/esp32evse/number.py
@@ -8,6 +8,7 @@ from esphome.const import (
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
     CONF_STEP,
+    EntityCategory,
     UNIT_AMPERE,
     UNIT_SECOND,
     UNIT_WATT,
@@ -37,10 +38,20 @@ _NUMBER_SCHEMA_SUPPORTS_LIMITS = "min_value" in inspect.signature(  # pragma: no
 ).parameters
 
 
-def _build_number_schema(icon, unit, default_min, default_max, default_step, default_multiplier):
+def _build_number_schema(
+    icon,
+    unit,
+    default_min,
+    default_max,
+    default_step,
+    default_multiplier,
+    entity_category=None,
+):
     kwargs = {"icon": icon}
     if unit is not None:
         kwargs["unit_of_measurement"] = unit
+    if entity_category is not None:
+        kwargs["entity_category"] = entity_category
     if _NUMBER_SCHEMA_SUPPORTS_LIMITS:
         kwargs.update(
             {
@@ -81,6 +92,7 @@ _NUMBER_TYPES = {
             default_max=63.0,
             default_step=0.1,
             default_multiplier=10.0,
+            entity_category=EntityCategory.CONFIG,
         ),
         "command": "AT+DEFCHCUR",
         "setter": "set_default_charging_current_number",
@@ -93,6 +105,7 @@ _NUMBER_TYPES = {
             default_max=63.0,
             default_step=0.1,
             default_multiplier=10.0,
+            entity_category=EntityCategory.CONFIG,
         ),
         "command": "AT+MAXCHCUR",
         "setter": "set_maximum_charging_current_number",
@@ -117,6 +130,7 @@ _NUMBER_TYPES = {
             default_max=100000.0,
             default_step=10.0,
             default_multiplier=1.0,
+            entity_category=EntityCategory.CONFIG,
         ),
         "command": "AT+DEFCONSUMLIM",
         "setter": "set_default_consumption_limit_number",
@@ -141,6 +155,7 @@ _NUMBER_TYPES = {
             default_max=86400.0,
             default_step=60.0,
             default_multiplier=1.0,
+            entity_category=EntityCategory.CONFIG,
         ),
         "command": "AT+DEFCHTIMELIM",
         "setter": "set_default_charging_time_limit_number",
@@ -165,6 +180,7 @@ _NUMBER_TYPES = {
             default_max=100000.0,
             default_step=10.0,
             default_multiplier=1.0,
+            entity_category=EntityCategory.CONFIG,
         ),
         "command": "AT+DEFUNDERPOWERLIM",
         "setter": "set_default_under_power_limit_number",

--- a/components/esp32evse/sensor.py
+++ b/components/esp32evse/sensor.py
@@ -7,6 +7,7 @@ from esphome.const import (
     DEVICE_CLASS_SIGNAL_STRENGTH,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_VOLTAGE,
+    EntityCategory,
     ICON_FLASH,
     ICON_THERMOMETER,
     ICON_TIMER,
@@ -53,6 +54,7 @@ CONFIG_SCHEMA = cv.All(
                 device_class=DEVICE_CLASS_TEMPERATURE,
                 state_class=STATE_CLASS_MEASUREMENT,
                 accuracy_decimals=2,
+                entity_category=EntityCategory.DIAGNOSTIC,
             ),
             cv.Optional(CONF_EMETER_POWER): sensor.sensor_schema(
                 device_class=DEVICE_CLASS_POWER,
@@ -74,6 +76,7 @@ CONFIG_SCHEMA = cv.All(
                 unit_of_measurement="B",
                 icon="mdi:memory",
                 state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=EntityCategory.DIAGNOSTIC,
             ),
             cv.Optional(CONF_ENERGY_CONSUMPTION): sensor.sensor_schema(
                 unit_of_measurement=UNIT_WATT_HOUR,
@@ -84,6 +87,7 @@ CONFIG_SCHEMA = cv.All(
                 unit_of_measurement=UNIT_WATT_HOUR,
                 icon="mdi:counter",
                 state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=EntityCategory.DIAGNOSTIC,
             ),
             cv.Optional(CONF_VOLTAGE_L1): sensor.sensor_schema(
                 unit_of_measurement=UNIT_VOLT,
@@ -126,6 +130,7 @@ CONFIG_SCHEMA = cv.All(
                 icon="mdi:wifi-strength-2",
                 device_class=DEVICE_CLASS_SIGNAL_STRENGTH,
                 state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=EntityCategory.DIAGNOSTIC,
             ),
         }
     ),

--- a/components/esp32evse/switch.py
+++ b/components/esp32evse/switch.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import switch
 import esphome.config_validation as cv
+from esphome.const import EntityCategory
 
 from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
 
@@ -28,10 +29,12 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_AVAILABLE): switch.switch_schema(
                 ESP32EVSEAvailableSwitch,
                 icon="mdi:check-network",
+                entity_category=EntityCategory.CONFIG,
             ),
             cv.Optional(CONF_REQUEST_AUTHORIZATION): switch.switch_schema(
                 ESP32EVSERequestAuthorizationSwitch,
                 icon="mdi:hand-back-right",
+                entity_category=EntityCategory.CONFIG,
             ),
         }
     ),

--- a/components/esp32evse/text_sensor.py
+++ b/components/esp32evse/text_sensor.py
@@ -1,6 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv
+from esphome.const import EntityCategory
 
 from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent
 
@@ -23,15 +24,33 @@ CONFIG_SCHEMA = cv.All(
         {
             cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
             cv.Optional(CONF_STATE): text_sensor.text_sensor_schema(icon="mdi:ev-station"),
-            cv.Optional(CONF_CHIP): text_sensor.text_sensor_schema(icon="mdi:chip"),
-            cv.Optional(CONF_VERSION): text_sensor.text_sensor_schema(icon="mdi:tag"),
-            cv.Optional(CONF_IDF_VERSION): text_sensor.text_sensor_schema(icon="mdi:alpha-i-circle"),
-            cv.Optional(CONF_BUILD_TIME): text_sensor.text_sensor_schema(icon="mdi:clock-outline"),
-            cv.Optional(CONF_DEVICE_TIME): text_sensor.text_sensor_schema(icon="mdi:clock"),
-            cv.Optional(CONF_WIFI_STA_SSID): text_sensor.text_sensor_schema(icon="mdi:wifi"),
-            cv.Optional(CONF_WIFI_STA_IP): text_sensor.text_sensor_schema(icon="mdi:ip"),
-            cv.Optional(CONF_WIFI_STA_MAC): text_sensor.text_sensor_schema(icon="mdi:lan"),
-            cv.Optional(CONF_DEVICE_NAME): text_sensor.text_sensor_schema(icon="mdi:rename-box"),
+            cv.Optional(CONF_CHIP): text_sensor.text_sensor_schema(
+                icon="mdi:chip", entity_category=EntityCategory.DIAGNOSTIC
+            ),
+            cv.Optional(CONF_VERSION): text_sensor.text_sensor_schema(
+                icon="mdi:tag", entity_category=EntityCategory.DIAGNOSTIC
+            ),
+            cv.Optional(CONF_IDF_VERSION): text_sensor.text_sensor_schema(
+                icon="mdi:alpha-i-circle", entity_category=EntityCategory.DIAGNOSTIC
+            ),
+            cv.Optional(CONF_BUILD_TIME): text_sensor.text_sensor_schema(
+                icon="mdi:clock-outline", entity_category=EntityCategory.DIAGNOSTIC
+            ),
+            cv.Optional(CONF_DEVICE_TIME): text_sensor.text_sensor_schema(
+                icon="mdi:clock", entity_category=EntityCategory.DIAGNOSTIC
+            ),
+            cv.Optional(CONF_WIFI_STA_SSID): text_sensor.text_sensor_schema(
+                icon="mdi:wifi", entity_category=EntityCategory.DIAGNOSTIC
+            ),
+            cv.Optional(CONF_WIFI_STA_IP): text_sensor.text_sensor_schema(
+                icon="mdi:ip", entity_category=EntityCategory.DIAGNOSTIC
+            ),
+            cv.Optional(CONF_WIFI_STA_MAC): text_sensor.text_sensor_schema(
+                icon="mdi:lan", entity_category=EntityCategory.DIAGNOSTIC
+            ),
+            cv.Optional(CONF_DEVICE_NAME): text_sensor.text_sensor_schema(
+                icon="mdi:rename-box", entity_category=EntityCategory.DIAGNOSTIC
+            ),
         }
     ),
     cv.has_at_least_one_key(


### PR DESCRIPTION
## Summary
- mark diagnostic binary, sensor, switch, and text sensor entities with the appropriate entity categories
- classify configuration-related number and switch entities with EntityCategory.CONFIG for better Home Assistant organization

## Testing
- python -m compileall components/esp32evse

------
https://chatgpt.com/codex/tasks/task_e_68d3dee3d8c4832786e27e7d9754cb01