### PR TITLE
Add separate high and low temperature sensors

### DIFF
--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -80,7 +80,7 @@ void ESP32EVSEComponent::setup() {
     this->request_enable_update();
     this->request_pending_authorization_update();
 
-    if (this->temperature_sensor_ != nullptr)
+    if (this->temperature_high_sensor_ != nullptr || this->temperature_low_sensor_ != nullptr)
       this->request_temperature_update();
     if (this->charging_current_number_ != nullptr)
       this->request_charging_current_update();
@@ -188,7 +188,7 @@ void ESP32EVSEComponent::update() {
   this->request_enable_update();
   this->request_pending_authorization_update();
 
-  if (this->temperature_sensor_ != nullptr)
+  if (this->temperature_high_sensor_ != nullptr || this->temperature_low_sensor_ != nullptr)
     this->request_temperature_update();
   if (this->charging_current_number_ != nullptr)
     this->request_charging_current_update();
@@ -642,16 +642,22 @@ void ESP32EVSEComponent::update_enable_(bool enable) {
 }
 
 void ESP32EVSEComponent::update_temperature_(int count, int32_t high, int32_t low) {
-  if (this->temperature_sensor_ == nullptr)
+  if (this->temperature_high_sensor_ == nullptr && this->temperature_low_sensor_ == nullptr)
     return;
   if (count <= 0) {
-    this->temperature_sensor_->publish_state(NAN);
+    if (this->temperature_high_sensor_ != nullptr)
+      this->temperature_high_sensor_->publish_state(NAN);
+    if (this->temperature_low_sensor_ != nullptr)
+      this->temperature_low_sensor_->publish_state(NAN);
     return;
   }
   float high_c = high / 100.0f;
   float low_c = low / 100.0f;
   ESP_LOGD(TAG, "Temperature sensors: %d, high %.2f°C, low %.2f°C", count, high_c, low_c);
-  this->temperature_sensor_->publish_state(high_c);
+  if (this->temperature_high_sensor_ != nullptr)
+    this->temperature_high_sensor_->publish_state(high_c);
+  if (this->temperature_low_sensor_ != nullptr)
+    this->temperature_low_sensor_->publish_state(low_c);
 }
 
 void ESP32EVSEComponent::publish_scaled_number_(ESP32EVSEChargingCurrentNumber *number, float raw_value) {

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -68,7 +68,13 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
     this->request_authorization_switch_ = sw;
   }
 
-  void set_temperature_sensor(sensor::Sensor *sensor) { this->temperature_sensor_ = sensor; }
+  void set_temperature_high_sensor(sensor::Sensor *sensor) {
+    this->temperature_high_sensor_ = sensor;
+  }
+  void set_temperature_low_sensor(sensor::Sensor *sensor) {
+    this->temperature_low_sensor_ = sensor;
+  }
+  void set_temperature_sensor(sensor::Sensor *sensor) { this->set_temperature_high_sensor(sensor); }
   void set_heap_sensor(sensor::Sensor *sensor) { this->heap_sensor_ = sensor; }
   void set_energy_consumption_sensor(sensor::Sensor *sensor) {
     this->energy_consumption_sensor_ = sensor;
@@ -243,7 +249,8 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   ESP32EVSEAvailableSwitch *available_switch_{nullptr};
   ESP32EVSERequestAuthorizationSwitch *request_authorization_switch_{nullptr};
 
-  sensor::Sensor *temperature_sensor_{nullptr};
+  sensor::Sensor *temperature_high_sensor_{nullptr};
+  sensor::Sensor *temperature_low_sensor_{nullptr};
   sensor::Sensor *heap_sensor_{nullptr};
   sensor::Sensor *energy_consumption_sensor_{nullptr};
   sensor::Sensor *total_energy_consumption_sensor_{nullptr};

--- a/components/esp32evse/sensor.py
+++ b/components/esp32evse/sensor.py
@@ -29,6 +29,8 @@ from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent
 DEPENDENCIES = ["esp32evse"]
 
 CONF_TEMPERATURE = "temperature"
+CONF_TEMPERATURE_HIGH = "temperature_high"
+CONF_TEMPERATURE_LOW = "temperature_low"
 CONF_EMETER_POWER = "emeter_power"
 CONF_EMETER_SESSION_TIME = "emeter_session_time"
 CONF_EMETER_CHARGING_TIME = "emeter_charging_time"
@@ -48,6 +50,22 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
+            cv.Optional(CONF_TEMPERATURE_HIGH): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                icon=ICON_THERMOMETER,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+                accuracy_decimals=2,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_TEMPERATURE_LOW): sensor.sensor_schema(
+                unit_of_measurement=UNIT_CELSIUS,
+                icon=ICON_THERMOMETER,
+                device_class=DEVICE_CLASS_TEMPERATURE,
+                state_class=STATE_CLASS_MEASUREMENT,
+                accuracy_decimals=2,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
             cv.Optional(CONF_TEMPERATURE): sensor.sensor_schema(
                 unit_of_measurement=UNIT_CELSIUS,
                 icon=ICON_THERMOMETER,
@@ -136,6 +154,8 @@ CONFIG_SCHEMA = cv.All(
     ),
     cv.has_at_least_one_key(
         CONF_TEMPERATURE,
+        CONF_TEMPERATURE_HIGH,
+        CONF_TEMPERATURE_LOW,
         CONF_EMETER_POWER,
         CONF_EMETER_SESSION_TIME,
         CONF_EMETER_CHARGING_TIME,
@@ -156,9 +176,15 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     parent = await cg.get_variable(config[CONF_ESP32EVSE_ID])
 
-    if temperature_config := config.get(CONF_TEMPERATURE):
+    if temperature_high_config := config.get(CONF_TEMPERATURE_HIGH):
+        sens = await sensor.new_sensor(temperature_high_config)
+        cg.add(parent.set_temperature_high_sensor(sens))
+    elif temperature_config := config.get(CONF_TEMPERATURE):
         sens = await sensor.new_sensor(temperature_config)
-        cg.add(parent.set_temperature_sensor(sens))
+        cg.add(parent.set_temperature_high_sensor(sens))
+    if temperature_low_config := config.get(CONF_TEMPERATURE_LOW):
+        sens = await sensor.new_sensor(temperature_low_config)
+        cg.add(parent.set_temperature_low_sensor(sens))
     if power_config := config.get(CONF_EMETER_POWER):
         sens = await sensor.new_sensor(power_config)
         cg.add(parent.set_emeter_power_sensor(sens))

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -81,8 +81,10 @@ number:
 sensor:
   - platform: esp32evse
     esp32evse_id: evse
-    temperature:
-      name: "EVSE Temperature"
+    temperature_high:
+      name: "EVSE Temperature High"
+    temperature_low:
+      name: "EVSE Temperature Low"
     emeter_power:
       name: "EVSE Power"
     emeter_session_time:


### PR DESCRIPTION
## Summary
- add new configuration keys for `temperature_high` and `temperature_low` sensors while keeping backwards compatibility
- publish both high and low temperature readings from the component
- update the example ESPHome configuration to showcase both sensors

## Testing
- python -m compileall components/esp32evse

------
https://chatgpt.com/codex/tasks/task_e_68d3e9c813b883279e4847edad5c4ac7