### PR TITLE
Add generic AT subscription wrappers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,5 +86,37 @@ communication multiplier where applicable.
 - Adjust number ranges to match the electrical limits of your installation.
 - Remove sections you do not need to reduce resource usage on the device.
 
+### Using generic AT subscriptions from YAML
+
+The component exposes helper methods so you can trigger `AT+SUB` / `AT+UNSUB`
+commands directly from ESPHome lambdas. This allows custom subscriptions beyond
+the built-in fast power helpers. For example, you can add buttons that control a
+subscription to the `EMETERPOWER` feed:
+
+```yaml
+button:
+  - platform: template
+    name: "Subscribe to EMETERPOWER"
+    on_press:
+      - lambda: |-
+          id(evse).subscribe_command("\"+EMETERPOWER\"", 1000);
+  - platform: template
+    name: "Unsubscribe from EMETERPOWER"
+    on_press:
+      - lambda: |-
+          id(evse).unsubscribe_command("\"+EMETERPOWER\"");
+```
+
+Passing an empty string to `unsubscribe_command()` sends a bare `AT+UNSUB`
+request, which clears every active subscription:
+
+```yaml
+  - platform: template
+    name: "Unsubscribe from all feeds"
+    on_press:
+      - lambda: |-
+          id(evse).unsubscribe_command("");
+```
+
 With the configuration in this repository you can quickly evaluate the ESP32EVSE
 component and tailor it to your own EV charging project.

--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -371,6 +371,24 @@ void ESP32EVSEComponent::unsubscribe_fast_power_updates() {
   this->send_command_("AT+UNSUB=\"+EMETERPOWER\"");
 }
 
+void ESP32EVSEComponent::subscribe_command(const std::string &command, uint32_t period_ms) {
+  ESP_LOGW(TAG, "Sending AT+SUB for command '%s' with period %" PRIu32 " ms", command.c_str(), period_ms);
+  std::string cmd = "AT+SUB=" + command + "," + std::to_string(period_ms);
+  this->send_command_(cmd);
+}
+
+void ESP32EVSEComponent::unsubscribe_command(const std::string &command) {
+  if (command.empty()) {
+    ESP_LOGW(TAG, "Sending AT+UNSUB without command parameter");
+    this->send_command_("AT+UNSUB");
+    return;
+  }
+
+  ESP_LOGW(TAG, "Sending AT+UNSUB for command '%s'", command.c_str());
+  std::string cmd = "AT+UNSUB=" + command;
+  this->send_command_(cmd);
+}
+
 void ESP32EVSEComponent::send_reset_command() { this->send_command_("AT+RST"); }
 
 void ESP32EVSEComponent::send_authorize_command() { this->send_command_("AT+AUTH"); }

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -182,6 +182,8 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
 
   void subscribe_fast_power_updates();
   void unsubscribe_fast_power_updates();
+  void subscribe_command(const std::string &command, uint32_t period_ms);
+  void unsubscribe_command(const std::string &command = "");
   void send_reset_command();
   void send_authorize_command();
 


### PR DESCRIPTION
## Summary
- add public wrappers for AT+SUB and AT+UNSUB so they can be called from YAML lambdas
- log a warning message whenever the wrappers are used to aid troubleshooting
- document EMETERPOWER subscription and matching unsubscribe examples for YAML lambdas

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3ecf2e2888327b1d2ff6600da64fb