### PR TITLE
Validate AT subscription arguments

### DIFF
--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -235,6 +235,7 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   bool send_command_(const std::string &command, std::function<void(bool)> callback = nullptr);
   void request_number_update_(ESP32EVSEChargingCurrentNumber *number);
   void publish_scaled_number_(ESP32EVSEChargingCurrentNumber *number, float raw_value);
+  bool is_valid_subscription_argument_(const std::string &argument) const;
 
   text_sensor::TextSensor *state_text_sensor_{nullptr};
   text_sensor::TextSensor *chip_text_sensor_{nullptr};


### PR DESCRIPTION
## Summary
- add validation to the AT+SUB and AT+UNSUB helpers so they only accept subscription targets and warn when other AT commands are provided
- share a helper that detects disallowed AT command substrings before sending the request

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3f18fecd88327a0bcbe0218f0c87e