### PR TITLE
Remove fast power subscription buttons

### DIFF
--- a/components/esp32evse/button.py
+++ b/components/esp32evse/button.py
@@ -7,17 +7,9 @@ from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
 
 DEPENDENCIES = ["esp32evse"]
 
-ESP32EVSEFastSubscribeButton = esp32evse_ns.class_(
-    "ESP32EVSEFastSubscribeButton", button.Button
-)
-ESP32EVSEFastUnsubscribeButton = esp32evse_ns.class_(
-    "ESP32EVSEFastUnsubscribeButton", button.Button
-)
 ESP32EVSEResetButton = esp32evse_ns.class_("ESP32EVSEResetButton", button.Button)
 ESP32EVSEAuthorizeButton = esp32evse_ns.class_("ESP32EVSEAuthorizeButton", button.Button)
 
-CONF_FAST_SUBSCRIBE = "fast_power_subscribe"
-CONF_FAST_UNSUBSCRIBE = "fast_power_unsubscribe"
 CONF_RESET = "reset"
 CONF_AUTHORIZE = "authorize"
 
@@ -26,14 +18,6 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
-            cv.Optional(CONF_FAST_SUBSCRIBE): button.button_schema(
-                ESP32EVSEFastSubscribeButton,
-                icon="mdi:speedometer",
-            ),
-            cv.Optional(CONF_FAST_UNSUBSCRIBE): button.button_schema(
-                ESP32EVSEFastUnsubscribeButton,
-                icon="mdi:speedometer-slow",
-            ),
             cv.Optional(CONF_RESET): button.button_schema(
                 ESP32EVSEResetButton,
                 icon="mdi:restart",
@@ -46,8 +30,6 @@ CONFIG_SCHEMA = cv.All(
         }
     ),
     cv.has_at_least_one_key(
-        CONF_FAST_SUBSCRIBE,
-        CONF_FAST_UNSUBSCRIBE,
         CONF_RESET,
         CONF_AUTHORIZE,
     ),
@@ -57,14 +39,6 @@ CONFIG_SCHEMA = cv.All(
 async def to_code(config):
     parent = await cg.get_variable(config[CONF_ESP32EVSE_ID])
 
-    if subscribe_config := config.get(CONF_FAST_SUBSCRIBE):
-        btn = await button.new_button(subscribe_config)
-        await cg.register_parented(btn, config[CONF_ESP32EVSE_ID])
-        cg.add(parent.set_fast_subscribe_button(btn))
-    if unsubscribe_config := config.get(CONF_FAST_UNSUBSCRIBE):
-        btn = await button.new_button(unsubscribe_config)
-        await cg.register_parented(btn, config[CONF_ESP32EVSE_ID])
-        cg.add(parent.set_fast_unsubscribe_button(btn))
     if reset_config := config.get(CONF_RESET):
         btn = await button.new_button(reset_config)
         await cg.register_parented(btn, config[CONF_ESP32EVSE_ID])

--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -965,18 +965,6 @@ void ESP32EVSEChargingCurrentNumber::control(float value) {
   this->parent_->write_number_value(this, value);
 }
 
-void ESP32EVSEFastSubscribeButton::press_action() {
-  if (this->parent_ == nullptr)
-    return;
-  this->parent_->subscribe_fast_power_updates();
-}
-
-void ESP32EVSEFastUnsubscribeButton::press_action() {
-  if (this->parent_ == nullptr)
-    return;
-  this->parent_->unsubscribe_fast_power_updates();
-}
-
 void ESP32EVSEResetButton::press_action() {
   if (this->parent_ == nullptr)
     return;

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -22,8 +22,6 @@ class ESP32EVSEEnableSwitch;
 class ESP32EVSEAvailableSwitch;
 class ESP32EVSERequestAuthorizationSwitch;
 class ESP32EVSEChargingCurrentNumber;
-class ESP32EVSEFastSubscribeButton;
-class ESP32EVSEFastUnsubscribeButton;
 class ESP32EVSEResetButton;
 class ESP32EVSEAuthorizeButton;
 class ESP32EVSEPendingAuthorizationBinarySensor;
@@ -126,10 +124,6 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
     this->emeter_charging_time_sensor_ = sensor;
   }
 
-  void set_fast_subscribe_button(ESP32EVSEFastSubscribeButton *btn) { this->fast_subscribe_button_ = btn; }
-  void set_fast_unsubscribe_button(ESP32EVSEFastUnsubscribeButton *btn) {
-    this->fast_unsubscribe_button_ = btn;
-  }
   void set_reset_button(ESP32EVSEResetButton *btn) { this->reset_button_ = btn; }
   void set_authorize_button(ESP32EVSEAuthorizeButton *btn) { this->authorize_button_ = btn; }
 
@@ -279,8 +273,6 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   sensor::Sensor *emeter_session_time_sensor_{nullptr};
   sensor::Sensor *emeter_charging_time_sensor_{nullptr};
 
-  ESP32EVSEFastSubscribeButton *fast_subscribe_button_{nullptr};
-  ESP32EVSEFastUnsubscribeButton *fast_unsubscribe_button_{nullptr};
   ESP32EVSEResetButton *reset_button_{nullptr};
   ESP32EVSEAuthorizeButton *authorize_button_{nullptr};
 
@@ -320,16 +312,6 @@ class ESP32EVSEChargingCurrentNumber : public number::Number, public Parented<ES
 
   std::string command_{"AT+CHCUR"};
   float multiplier_{10.0f};
-};
-
-class ESP32EVSEFastSubscribeButton : public button::Button, public Parented<ESP32EVSEComponent> {
- protected:
-  void press_action() override;
-};
-
-class ESP32EVSEFastUnsubscribeButton : public button::Button, public Parented<ESP32EVSEComponent> {
- protected:
-  void press_action() override;
 };
 
 class ESP32EVSEResetButton : public button::Button, public Parented<ESP32EVSEComponent> {

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -47,10 +47,6 @@ binary_sensor:
 button:
   - platform: esp32evse
     esp32evse_id: evse
-    fast_power_subscribe:
-      name: "EVSE Fast Power Subscribe"
-    fast_power_unsubscribe:
-      name: "EVSE Fast Power Unsubscribe"
     reset:
       name: "EVSE Reset"
     authorize:


### PR DESCRIPTION
## Summary
- remove the fast power subscribe and unsubscribe buttons from the sample configuration
- drop the associated ESPHome component classes and config options for the fast power buttons

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d3f29b83b483278f5a6265cf991294