### PR TITLE
Fix unsubscribe-all command

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,8 @@ button:
           id(evse).unsubscribe_command("\"+EMETERPOWER\"");
 ```
 
-Passing an empty string to `unsubscribe_command()` sends a bare `AT+UNSUB`
-request, which clears every active subscription:
+Passing an empty string to `unsubscribe_command()` sends `AT+UNSUB=""`,
+which clears every active subscription:
 
 ```yaml
   - platform: template

--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -385,8 +385,8 @@ void ESP32EVSEComponent::subscribe_command(const std::string &command, uint32_t 
 
 void ESP32EVSEComponent::unsubscribe_command(const std::string &command) {
   if (command.empty()) {
-    ESP_LOGW(TAG, "Sending AT+UNSUB without command parameter");
-    this->send_command_("AT+UNSUB");
+    ESP_LOGW(TAG, "Sending AT+UNSUB with empty command parameter");
+    this->send_command_("AT+UNSUB=\"\"");
     return;
   }
 


### PR DESCRIPTION
## Summary
- send AT+UNSUB with an explicit empty parameter so the device accepts the unsubscribe-all request
- update the documentation to match the corrected command format

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3f5bc5e888327959c969ad53a75af