### PR TITLE
Rename subscription helpers to at_sub/at_unsub

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,15 +99,15 @@ button:
     name: "Subscribe to EMETERPOWER"
     on_press:
       - lambda: |-
-          id(evse).subscribe_command("\"+EMETERPOWER\"", 1000);
+          id(evse).at_sub("\"+EMETERPOWER\"", 1000);
   - platform: template
     name: "Unsubscribe from EMETERPOWER"
     on_press:
       - lambda: |-
-          id(evse).unsubscribe_command("\"+EMETERPOWER\"");
+          id(evse).at_unsub("\"+EMETERPOWER\"");
 ```
 
-Passing an empty string to `unsubscribe_command()` sends `AT+UNSUB=""`,
+Passing an empty string to `at_unsub()` sends `AT+UNSUB=""`,
 which clears every active subscription:
 
 ```yaml
@@ -115,7 +115,7 @@ which clears every active subscription:
     name: "Unsubscribe from all feeds"
     on_press:
       - lambda: |-
-          id(evse).unsubscribe_command("");
+          id(evse).at_unsub("");
 ```
 
 With the configuration in this repository you can quickly evaluate the ESP32EVSE

--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -371,7 +371,7 @@ void ESP32EVSEComponent::unsubscribe_fast_power_updates() {
   this->send_command_("AT+UNSUB=\"+EMETERPOWER\"");
 }
 
-void ESP32EVSEComponent::subscribe_command(const std::string &command, uint32_t period_ms) {
+void ESP32EVSEComponent::at_sub(const std::string &command, uint32_t period_ms) {
   if (!this->is_valid_subscription_argument_(command)) {
     ESP_LOGW(TAG,
              "Rejected AT+SUB wrapper request with argument '%s'; only subscription targets are allowed",
@@ -383,7 +383,7 @@ void ESP32EVSEComponent::subscribe_command(const std::string &command, uint32_t 
   this->send_command_(cmd);
 }
 
-void ESP32EVSEComponent::unsubscribe_command(const std::string &command) {
+void ESP32EVSEComponent::at_unsub(const std::string &command) {
   if (command.empty()) {
     ESP_LOGW(TAG, "Sending AT+UNSUB with empty command parameter");
     this->send_command_("AT+UNSUB=\"\"");

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -176,8 +176,8 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
 
   void subscribe_fast_power_updates();
   void unsubscribe_fast_power_updates();
-  void subscribe_command(const std::string &command, uint32_t period_ms);
-  void unsubscribe_command(const std::string &command = "");
+  void at_sub(const std::string &command, uint32_t period_ms);
+  void at_unsub(const std::string &command = "");
   void send_reset_command();
   void send_authorize_command();
 


### PR DESCRIPTION
## Summary
- rename the public subscription helper methods to at_sub and at_unsub
- update the component implementation and README examples to use the new names

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3f6c7fce08327a7bfb5ac8f3f9b4d