### PR TITLE
Add separate heap used and total sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ or commenting out the related sections in `esphome.yaml`.
 
 - **Temperatures**
 - **Power**, **session duration**, and **charging duration**
-- **Free heap memory**
+- **Heap memory usage** (used and total)
 - **Session time** and **total energy consumption**
 - **Line voltages** (L1/L2/L3)
 - **Line currents** (L1/L2/L3)

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -13,6 +13,7 @@
 
 #include <deque>
 #include <functional>
+#include <optional>
 #include <string>
 
 namespace esphome {
@@ -73,7 +74,9 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
     this->temperature_low_sensor_ = sensor;
   }
   void set_temperature_sensor(sensor::Sensor *sensor) { this->set_temperature_high_sensor(sensor); }
-  void set_heap_sensor(sensor::Sensor *sensor) { this->heap_sensor_ = sensor; }
+  void set_heap_sensor(sensor::Sensor *sensor) { this->set_heap_used_sensor(sensor); }
+  void set_heap_used_sensor(sensor::Sensor *sensor) { this->heap_used_sensor_ = sensor; }
+  void set_heap_total_sensor(sensor::Sensor *sensor) { this->heap_total_sensor_ = sensor; }
   void set_energy_consumption_sensor(sensor::Sensor *sensor) {
     this->energy_consumption_sensor_ = sensor;
   }
@@ -210,7 +213,8 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   void update_device_name_(const std::string &name);
   void update_available_(bool available);
   void update_request_authorization_(bool request);
-  void update_heap_(uint32_t heap_bytes);
+  void update_heap_(std::optional<uint32_t> heap_used_bytes,
+                    std::optional<uint32_t> heap_total_bytes);
   void update_energy_consumption_(float value);
   void update_total_energy_consumption_(float value);
   void update_voltages_(float l1, float l2, float l3);
@@ -249,7 +253,8 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
 
   sensor::Sensor *temperature_high_sensor_{nullptr};
   sensor::Sensor *temperature_low_sensor_{nullptr};
-  sensor::Sensor *heap_sensor_{nullptr};
+  sensor::Sensor *heap_used_sensor_{nullptr};
+  sensor::Sensor *heap_total_sensor_{nullptr};
   sensor::Sensor *energy_consumption_sensor_{nullptr};
   sensor::Sensor *total_energy_consumption_sensor_{nullptr};
   sensor::Sensor *voltage_l1_sensor_{nullptr};

--- a/components/esp32evse/sensor.py
+++ b/components/esp32evse/sensor.py
@@ -38,6 +38,8 @@ CONF_EMETER_POWER = "emeter_power"
 CONF_EMETER_SESSION_TIME = "emeter_session_time"
 CONF_EMETER_CHARGING_TIME = "emeter_charging_time"
 CONF_HEAP = "heap"
+CONF_HEAP_USED = "heap_used"
+CONF_HEAP_TOTAL = "heap_total"
 CONF_ENERGY_CONSUMPTION = "energy_consumption"
 CONF_TOTAL_ENERGY_CONSUMPTION = "total_energy_consumption"
 CONF_VOLTAGE_L1 = "voltage_l1"
@@ -94,6 +96,18 @@ CONFIG_SCHEMA = cv.All(
                 state_class=STATE_CLASS_MEASUREMENT,
             ),
             cv.Optional(CONF_HEAP): sensor.sensor_schema(
+                unit_of_measurement="B",
+                icon="mdi:memory",
+                state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_HEAP_USED): sensor.sensor_schema(
+                unit_of_measurement="B",
+                icon="mdi:memory",
+                state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
+            ),
+            cv.Optional(CONF_HEAP_TOTAL): sensor.sensor_schema(
                 unit_of_measurement="B",
                 icon="mdi:memory",
                 state_class=STATE_CLASS_MEASUREMENT,
@@ -171,6 +185,8 @@ CONFIG_SCHEMA = cv.All(
         CONF_EMETER_SESSION_TIME,
         CONF_EMETER_CHARGING_TIME,
         CONF_HEAP,
+        CONF_HEAP_USED,
+        CONF_HEAP_TOTAL,
         CONF_ENERGY_CONSUMPTION,
         CONF_TOTAL_ENERGY_CONSUMPTION,
         CONF_VOLTAGE_L1,
@@ -205,9 +221,15 @@ async def to_code(config):
     if charging_config := config.get(CONF_EMETER_CHARGING_TIME):
         sens = await sensor.new_sensor(charging_config)
         cg.add(parent.set_emeter_charging_time_sensor(sens))
-    if heap_config := config.get(CONF_HEAP):
+    if heap_used_config := config.get(CONF_HEAP_USED):
+        sens = await sensor.new_sensor(heap_used_config)
+        cg.add(parent.set_heap_used_sensor(sens))
+    elif heap_config := config.get(CONF_HEAP):
         sens = await sensor.new_sensor(heap_config)
-        cg.add(parent.set_heap_sensor(sens))
+        cg.add(parent.set_heap_used_sensor(sens))
+    if heap_total_config := config.get(CONF_HEAP_TOTAL):
+        sens = await sensor.new_sensor(heap_total_config)
+        cg.add(parent.set_heap_total_sensor(sens))
     if energy_config := config.get(CONF_ENERGY_CONSUMPTION):
         sens = await sensor.new_sensor(energy_config)
         cg.add(parent.set_energy_consumption_sensor(sens))

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -87,8 +87,10 @@ sensor:
       name: "EVSE Session Time"
     emeter_charging_time:
       name: "EVSE Charging Time"
-    heap:
-      name: "EVSE Free Heap"
+    heap_used:
+      name: "EVSE Heap Used"
+    heap_total:
+      name: "EVSE Heap Total"
     energy_consumption:
       name: "EVSE Session Energy"
     total_energy_consumption:


### PR DESCRIPTION
## Summary
- parse AT+HEAP responses for both used and total heap values and publish them to dedicated sensors
- add configuration options for `heap_used` and `heap_total` while keeping the legacy `heap` mapping
- document the new sensors and update the example configuration

## Testing
- python -m compileall components

------
https://chatgpt.com/codex/tasks/task_e_68d510e9125c8327838cddf80596f008