### PR TITLE
Set box mode default for ESP32 EVSE numbers

### DIFF
--- a/components/esp32evse/number.py
+++ b/components/esp32evse/number.py
@@ -40,12 +40,6 @@ _NUMBER_SCHEMA_SUPPORTS_MODE = "mode" in inspect.signature(  # pragma: no branch
     number.number_schema
 ).parameters
 
-_NUMBER_MODE_BOX = None
-if hasattr(number, "NumberMode"):
-    _NUMBER_MODE_BOX = getattr(number.NumberMode, "NUMBER_MODE_BOX", None)
-elif hasattr(number, "NUMBER_MODE_BOX"):
-    _NUMBER_MODE_BOX = number.NUMBER_MODE_BOX
-
 
 def _build_number_schema(
     icon,
@@ -61,8 +55,8 @@ def _build_number_schema(
         kwargs["unit_of_measurement"] = unit
     if entity_category is not None:
         kwargs["entity_category"] = entity_category
-    if _NUMBER_SCHEMA_SUPPORTS_MODE and _NUMBER_MODE_BOX is not None:
-        kwargs["mode"] = _NUMBER_MODE_BOX
+    if _NUMBER_SCHEMA_SUPPORTS_MODE:
+        kwargs["mode"] = number.NumberMode.BOX
     if _NUMBER_SCHEMA_SUPPORTS_LIMITS:
         kwargs.update(
             {


### PR DESCRIPTION
## Summary
- remove the legacy compatibility logic for number mode detection
- default all ESP32 EVSE numbers to use box mode while remaining overridable

## Testing
- python -m compileall components/esp32evse


------
https://chatgpt.com/codex/tasks/task_e_68d52cee100c83278d3c889324624aff