### PR TITLE
Default ESP32EVSE numbers to box mode

### DIFF
--- a/components/esp32evse/number.py
+++ b/components/esp32evse/number.py
@@ -7,6 +7,7 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
+    CONF_MODE,
     CONF_STEP,
     ENTITY_CATEGORY_CONFIG,
     UNIT_AMPERE,
@@ -210,6 +211,9 @@ async def to_code(config):
         min_value = number_config.get(CONF_MIN_VALUE, defaults[CONF_MIN_VALUE])
         max_value = number_config.get(CONF_MAX_VALUE, defaults[CONF_MAX_VALUE])
         step = number_config.get(CONF_STEP, defaults[CONF_STEP])
+        if CONF_MODE not in number_config:
+            number_config = dict(number_config)
+            number_config[CONF_MODE] = number.NumberMode.BOX
         num = await number.new_number(
             number_config,
             min_value=min_value,


### PR DESCRIPTION
## Summary
- ensure the ESP32EVSE number schema imports `CONF_MODE` so a default can be applied
- default any generated number configuration to BOX mode before creating the number entity

## Testing
- `esphome config esphome.yaml` *(fails: command not found: esphome)*

------
https://chatgpt.com/codex/tasks/task_e_68d52ee232dc8327b52afb49bc42ae1e