### PR TITLE
Set ESP32EVSE numbers to BOX mode

### DIFF
--- a/components/esp32evse/number.py
+++ b/components/esp32evse/number.py
@@ -36,10 +36,6 @@ CONF_MULTIPLIER = "multiplier"
 _NUMBER_SCHEMA_SUPPORTS_LIMITS = "min_value" in inspect.signature(  # pragma: no branch
     number.number_schema
 ).parameters
-_NUMBER_SCHEMA_SUPPORTS_MODE = "mode" in inspect.signature(  # pragma: no branch
-    number.number_schema
-).parameters
-
 
 def _build_number_schema(
     icon,
@@ -49,14 +45,15 @@ def _build_number_schema(
     default_step,
     default_multiplier,
     entity_category=None,
+    mode=None,
 ):
     kwargs = {"icon": icon}
     if unit is not None:
         kwargs["unit_of_measurement"] = unit
     if entity_category is not None:
         kwargs["entity_category"] = entity_category
-    if _NUMBER_SCHEMA_SUPPORTS_MODE:
-        kwargs["mode"] = number.NumberMode.BOX
+    if mode is not None:
+        kwargs["mode"] = mode
     if _NUMBER_SCHEMA_SUPPORTS_LIMITS:
         kwargs.update(
             {
@@ -65,7 +62,11 @@ def _build_number_schema(
                 "step": default_step,
             }
         )
-    base = number.number_schema(ESP32EVSEChargingCurrentNumber, **kwargs)
+    try:
+        base = number.number_schema(ESP32EVSEChargingCurrentNumber, **kwargs)
+    except TypeError:
+        kwargs.pop("mode", None)
+        base = number.number_schema(ESP32EVSEChargingCurrentNumber, **kwargs)
     schema = base.extend(
         {
             cv.Optional(CONF_MIN_VALUE): cv.float_,
@@ -96,6 +97,7 @@ _NUMBER_TYPES = {
         default_max=63.0,
         default_step=0.1,
         default_multiplier=10.0,
+        mode=number.NumberMode.BOX,
         command="AT+CHCUR",
         setter="set_charging_current_number",
     ),
@@ -107,6 +109,7 @@ _NUMBER_TYPES = {
         default_step=0.1,
         default_multiplier=10.0,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        mode=number.NumberMode.BOX,
         command="AT+DEFCHCUR",
         setter="set_default_charging_current_number",
     ),
@@ -118,6 +121,7 @@ _NUMBER_TYPES = {
         default_step=1.0,
         default_multiplier=1.0,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        mode=number.NumberMode.BOX,
         command="AT+MAXCHCUR",
         setter="set_maximum_charging_current_number",
     ),
@@ -128,6 +132,7 @@ _NUMBER_TYPES = {
         default_max=100000.0,
         default_step=10.0,
         default_multiplier=1.0,
+        mode=number.NumberMode.BOX,
         command="AT+CONSUMLIM",
         setter="set_consumption_limit_number",
     ),
@@ -139,6 +144,7 @@ _NUMBER_TYPES = {
         default_step=10.0,
         default_multiplier=1.0,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        mode=number.NumberMode.BOX,
         command="AT+DEFCONSUMLIM",
         setter="set_default_consumption_limit_number",
     ),
@@ -149,6 +155,7 @@ _NUMBER_TYPES = {
         default_max=86400.0,
         default_step=60.0,
         default_multiplier=1.0,
+        mode=number.NumberMode.BOX,
         command="AT+CHTIMELIM",
         setter="set_charging_time_limit_number",
     ),
@@ -160,6 +167,7 @@ _NUMBER_TYPES = {
         default_step=60.0,
         default_multiplier=1.0,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        mode=number.NumberMode.BOX,
         command="AT+DEFCHTIMELIM",
         setter="set_default_charging_time_limit_number",
     ),
@@ -170,6 +178,7 @@ _NUMBER_TYPES = {
         default_max=100000.0,
         default_step=10.0,
         default_multiplier=1.0,
+        mode=number.NumberMode.BOX,
         command="AT+UNDERPOWERLIM",
         setter="set_under_power_limit_number",
     ),
@@ -181,6 +190,7 @@ _NUMBER_TYPES = {
         default_step=10.0,
         default_multiplier=1.0,
         entity_category=ENTITY_CATEGORY_CONFIG,
+        mode=number.NumberMode.BOX,
         command="AT+DEFUNDERPOWERLIM",
         setter="set_default_under_power_limit_number",
     ),


### PR DESCRIPTION
## Summary
- set the ESP32EVSE number entities to use BOX mode via the number type metadata
- fall back gracefully when BOX mode is not supported by the running ESPHome version

## Testing
- python -m compileall components

------
https://chatgpt.com/codex/tasks/task_e_68d530dc8d3c8327a79d7f58766b81be