### PR TITLE
Remove BOX mode fallback handling

### DIFF
--- a/components/esp32evse/number.py
+++ b/components/esp32evse/number.py
@@ -62,11 +62,7 @@ def _build_number_schema(
                 "step": default_step,
             }
         )
-    try:
-        base = number.number_schema(ESP32EVSEChargingCurrentNumber, **kwargs)
-    except TypeError:
-        kwargs.pop("mode", None)
-        base = number.number_schema(ESP32EVSEChargingCurrentNumber, **kwargs)
+    base = number.number_schema(ESP32EVSEChargingCurrentNumber, **kwargs)
     schema = base.extend(
         {
             cv.Optional(CONF_MIN_VALUE): cv.float_,


### PR DESCRIPTION
## Summary
- always pass BOX mode when building number schemas now that ESPHome versions support it

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d53238835c8327a9b6a887c1448dbe