### PR TITLE
Handle number mode compatibility

### DIFF
--- a/components/esp32evse/number.py
+++ b/components/esp32evse/number.py
@@ -7,6 +7,7 @@ import esphome.config_validation as cv
 from esphome.const import (
     CONF_MAX_VALUE,
     CONF_MIN_VALUE,
+    CONF_MODE,
     CONF_STEP,
     ENTITY_CATEGORY_CONFIG,
     UNIT_AMPERE,
@@ -36,6 +37,15 @@ CONF_MULTIPLIER = "multiplier"
 _NUMBER_SCHEMA_SUPPORTS_LIMITS = "min_value" in inspect.signature(  # pragma: no branch
     number.number_schema
 ).parameters
+_NUMBER_SCHEMA_SUPPORTS_MODE = "mode" in inspect.signature(  # pragma: no branch
+    number.number_schema
+).parameters
+
+
+def _normalize_mode(mode):
+    if mode is None:
+        return None
+    return getattr(mode, "value", mode)
 
 def _build_number_schema(
     icon,
@@ -52,7 +62,8 @@ def _build_number_schema(
         kwargs["unit_of_measurement"] = unit
     if entity_category is not None:
         kwargs["entity_category"] = entity_category
-    if mode is not None:
+    normalized_mode = _normalize_mode(mode)
+    if mode is not None and _NUMBER_SCHEMA_SUPPORTS_MODE:
         kwargs["mode"] = mode
     if _NUMBER_SCHEMA_SUPPORTS_LIMITS:
         kwargs.update(
@@ -63,14 +74,18 @@ def _build_number_schema(
             }
         )
     base = number.number_schema(ESP32EVSEChargingCurrentNumber, **kwargs)
-    schema = base.extend(
-        {
-            cv.Optional(CONF_MIN_VALUE): cv.float_,
-            cv.Optional(CONF_MAX_VALUE): cv.float_,
-            cv.Optional(CONF_STEP): cv.positive_float,
-            cv.Optional(CONF_MULTIPLIER): cv.positive_float,
-        }
-    )
+    extend_schema = {
+        cv.Optional(CONF_MIN_VALUE): cv.float_,
+        cv.Optional(CONF_MAX_VALUE): cv.float_,
+        cv.Optional(CONF_STEP): cv.positive_float,
+        cv.Optional(CONF_MULTIPLIER): cv.positive_float,
+    }
+    if mode is not None and not _NUMBER_SCHEMA_SUPPORTS_MODE:
+        extend_schema[cv.Optional(CONF_MODE, default=normalized_mode)] = cv.one_of(
+            *[m.value for m in number.NumberMode],
+            lower=True,
+        )
+    schema = base.extend(extend_schema)
     defaults = {
         CONF_MIN_VALUE: default_min,
         CONF_MAX_VALUE: default_max,


### PR DESCRIPTION
## Summary
- avoid passing the `mode` keyword to `number_schema` when the ESPHome core does not support it
- add a schema fallback so older cores still receive a default `mode` option

## Testing
- python -m compileall components/esp32evse

------
https://chatgpt.com/codex/tasks/task_e_68d5342001388327b9e64200acbf418f