### PR TITLE
Remove heap compatibility and clean platform references

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ or commenting out the related sections in `esphome.yaml`.
 
 ## Customization tips
 
-- Rename entities to match your Home Assistant naming convention.
+- Rename entities to match your automation platform naming convention.
 - Adjust number ranges to match the electrical limits of your installation.
 - Remove sections you do not need to reduce resource usage on the device.
 

--- a/components/esp32evse/binary_sensor.py
+++ b/components/esp32evse/binary_sensor.py
@@ -1,7 +1,7 @@
 """Configuration helpers for the ESP32 EVSE binary sensors.
 
 Each section below explains what kind of binary sensor is exposed to ESPHome
-and why we forward the data from the EVSE controller to Home Assistant.
+and why we forward the data from the EVSE controller to user-facing dashboards.
 """
 
 # Import the code generation helpers used to hook the sensors into the C++

--- a/components/esp32evse/button.py
+++ b/components/esp32evse/button.py
@@ -13,7 +13,7 @@ from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
 DEPENDENCIES = ["esp32evse"]
 
 # Define the lightweight C++ wrappers representing the actions we can trigger
-# on the EVSE controller from Home Assistant.
+# on the EVSE controller from client applications.
 ESP32EVSEResetButton = esp32evse_ns.class_("ESP32EVSEResetButton", button.Button)
 ESP32EVSEAuthorizeButton = esp32evse_ns.class_("ESP32EVSEAuthorizeButton", button.Button)
 

--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -41,7 +41,7 @@ const char *value_after_prefix(const std::string &line, const char *prefix) {
 }
 
 // Utility: trim whitespace and optional quotes from a string returned by the
-// EVSE so we can forward clean values to Home Assistant.
+// EVSE so we can forward clean values to downstream consumers.
 std::string trim_copy(const char *value) {
   if (value == nullptr)
     return {};
@@ -789,7 +789,7 @@ void ESP32EVSEComponent::update_temperature_(int count, int32_t high, int32_t lo
 }
 
 // Helper: convert the raw integer value reported by the EVSE into the scaled
-// float Home Assistant expects, then publish it on the number entity.
+// float the number entity expects before publishing it.
 void ESP32EVSEComponent::publish_scaled_number_(ESP32EVSEChargingCurrentNumber *number, float raw_value) {
   if (number == nullptr)
     return;
@@ -801,7 +801,7 @@ void ESP32EVSEComponent::publish_scaled_number_(ESP32EVSEChargingCurrentNumber *
 }
 
 // Helper: only publish text sensor updates when the value actually changes to
-// avoid unnecessary state spam in Home Assistant.
+// avoid unnecessary state spam for subscribers.
 void ESP32EVSEComponent::publish_text_sensor_state_(text_sensor::TextSensor *sensor,
                                                     const std::string &state) {
   if (sensor == nullptr)

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -84,7 +84,6 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
     this->temperature_low_sensor_ = sensor;
   }
   void set_temperature_sensor(sensor::Sensor *sensor) { this->set_temperature_high_sensor(sensor); }
-  void set_heap_sensor(sensor::Sensor *sensor) { this->set_heap_used_sensor(sensor); }
   void set_heap_used_sensor(sensor::Sensor *sensor) { this->heap_used_sensor_ = sensor; }
   void set_heap_total_sensor(sensor::Sensor *sensor) { this->heap_total_sensor_ = sensor; }
   void set_energy_consumption_sensor(sensor::Sensor *sensor) {
@@ -312,7 +311,7 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
 };
 
 // Lightweight wrappers for the ESPHome entity classes.  They forward state
-// changes initiated from Home Assistant back to the component implementation.
+// changes initiated from external clients back to the component implementation.
 class ESP32EVSEEnableSwitch : public switch_::Switch, public Parented<ESP32EVSEComponent> {
  protected:
   void write_state(bool state) override;

--- a/components/esp32evse/sensor.py
+++ b/components/esp32evse/sensor.py
@@ -41,7 +41,6 @@ CONF_TEMPERATURE_LOW = "temperature_low"
 CONF_EMETER_POWER = "emeter_power"
 CONF_EMETER_SESSION_TIME = "emeter_session_time"
 CONF_EMETER_CHARGING_TIME = "emeter_charging_time"
-CONF_HEAP = "heap"
 CONF_HEAP_USED = "heap_used"
 CONF_HEAP_TOTAL = "heap_total"
 CONF_ENERGY_CONSUMPTION = "energy_consumption"
@@ -100,12 +99,6 @@ CONFIG_SCHEMA = cv.All(
                 unit_of_measurement=UNIT_SECOND,
                 icon=ICON_TIMER,
                 state_class=STATE_CLASS_MEASUREMENT,
-            ),
-            cv.Optional(CONF_HEAP): sensor.sensor_schema(
-                unit_of_measurement="B",
-                icon="mdi:memory",
-                state_class=STATE_CLASS_MEASUREMENT,
-                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_HEAP_USED): sensor.sensor_schema(
                 unit_of_measurement="B",
@@ -190,7 +183,6 @@ CONFIG_SCHEMA = cv.All(
         CONF_EMETER_POWER,
         CONF_EMETER_SESSION_TIME,
         CONF_EMETER_CHARGING_TIME,
-        CONF_HEAP,
         CONF_HEAP_USED,
         CONF_HEAP_TOTAL,
         CONF_ENERGY_CONSUMPTION,
@@ -235,10 +227,6 @@ async def to_code(config):
         cg.add(parent.set_emeter_charging_time_sensor(sens))
     if heap_used_config := config.get(CONF_HEAP_USED):
         sens = await sensor.new_sensor(heap_used_config)
-        cg.add(parent.set_heap_used_sensor(sens))
-    elif heap_config := config.get(CONF_HEAP):
-        # Older configurations may reference ``heap`` instead of ``heap_used``.
-        sens = await sensor.new_sensor(heap_config)
         cg.add(parent.set_heap_used_sensor(sens))
     if heap_total_config := config.get(CONF_HEAP_TOTAL):
         sens = await sensor.new_sensor(heap_total_config)

--- a/components/esp32evse/switch.py
+++ b/components/esp32evse/switch.py
@@ -12,7 +12,7 @@ from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
 DEPENDENCIES = ["esp32evse"]
 
 # Define the C++ wrappers for each control surface we expose.  They allow the
-# component implementation to push state updates back to Home Assistant.
+# component implementation to push state updates back to connected clients.
 ESP32EVSEEnableSwitch = esp32evse_ns.class_("ESP32EVSEEnableSwitch", switch.Switch)
 ESP32EVSEAvailableSwitch = esp32evse_ns.class_("ESP32EVSEAvailableSwitch", switch.Switch)
 ESP32EVSERequestAuthorizationSwitch = esp32evse_ns.class_(

--- a/components/esp32evse/text_sensor.py
+++ b/components/esp32evse/text_sensor.py
@@ -1,7 +1,7 @@
 """Expose EVSE metadata strings (like firmware version) as text sensors."""
 
-# Text sensors surface raw strings to Home Assistant.  The helpers below create
-# them from user configuration and link them back to the EVSE component.
+# Text sensors surface raw strings to dashboards.  The helpers below create them
+# from user configuration and link them back to the EVSE component.
 import esphome.codegen as cg
 from esphome.components import text_sensor
 import esphome.config_validation as cv

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -1,5 +1,5 @@
-# Core firmware metadata so the node shows up with a friendly name inside ESPHome
-# Dashboard and Home Assistant.
+# Core firmware metadata so the node shows up with a friendly name inside the ESPHome
+# Dashboard and other management tools.
 esphome:
   name: esp32evse_dev
 
@@ -26,7 +26,7 @@ wifi:
 # point mode.
 captive_portal:
 
-# Home Assistant native API support for remote control and monitoring.
+# Native API support for remote control and monitoring.
 api:
 
 # Enable over-the-air firmware updates to avoid physical serial connections once
@@ -75,7 +75,7 @@ button:
       name: "EVSE Authorize"
 
 # Numeric entities expose adjustable parameters like charging current limits to
-# Home Assistant automations.
+# automation rules.
 number:
   - platform: esp32evse
     esp32evse_id: evse
@@ -107,6 +107,10 @@ sensor:
       name: "EVSE Temperature High"
     temperature_low:
       name: "EVSE Temperature Low"
+    # If your installation only uses a single probe, expose it via the combined
+    # ``temperature`` key instead of the individual high/low entries:
+    # temperature:
+    #   name: "EVSE Temperature"
     emeter_power:
       name: "EVSE Power"
     emeter_session_time:


### PR DESCRIPTION
## Summary
- drop the legacy heap sensor alias from the custom component configuration
- document how to configure a single temperature probe in the example YAML
- rewrite comments and docs to avoid naming external automation platforms directly

## Testing
- python -m compileall components/esp32evse


------
https://chatgpt.com/codex/tasks/task_e_68d54c03abec832788ef85df9af03534