### PR TITLE
Remove obsolete fast power subscription helpers

### DIFF
--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -409,16 +409,6 @@ void ESP32EVSEComponent::write_number_value(ESP32EVSEChargingCurrentNumber *numb
   });
 }
 
-// Convenience wrappers for popular subscription targets.  They are exposed to
-// users through templated buttons in YAML.
-void ESP32EVSEComponent::subscribe_fast_power_updates() {
-  this->send_command_("AT+SUB=\"+EMETERPOWER\",500");
-}
-
-void ESP32EVSEComponent::unsubscribe_fast_power_updates() {
-  this->send_command_("AT+UNSUB=\"+EMETERPOWER\"");
-}
-
 void ESP32EVSEComponent::at_sub(const std::string &command, uint32_t period_ms) {
   if (!this->is_valid_subscription_argument_(command)) {
     ESP_LOGW(TAG,

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -195,8 +195,6 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
 
   // Helpers for managing optional high-frequency subscriptions exposed by the
   // EVSE firmware (for example, power telemetry feeds).
-  void subscribe_fast_power_updates();
-  void unsubscribe_fast_power_updates();
   void at_sub(const std::string &command, uint32_t period_ms);
   void at_unsub(const std::string &command = "");
   void send_reset_command();


### PR DESCRIPTION
## Summary
- remove the unused subscribe_fast_power_updates and unsubscribe_fast_power_updates helpers
- rely on the generic at_sub/at_unsub helpers for managing subscriptions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d55657f0d88327b585abc48794370f