### PR TITLE
Add ESP32 EVSE autoupdate action

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,4 +113,34 @@ which clears every active subscription:
           id(evse).at_unsub("");
 ```
 
+### Using the `esp32evse.autoupdate` action
+
+Manually calling `at_sub()` from lambdas is powerful but requires remembering
+the AT command names. The component therefore also exposes an
+`esp32evse.autoupdate` action that maps the command from the entity ID:
+
+```yaml
+text_sensor:
+  - platform: esp32evse
+    esp32evse_id: evse
+    state:
+      id: evse_state
+
+interval:
+  - interval: 10s
+    then:
+      - esp32evse.autoupdate:
+          id: evse_state
+          period: 1000
+```
+
+When invoked with a non-zero period the action subscribes to the fast update
+feed associated with the entity. Passing `0` unsubscribes from the same feed:
+
+```yaml
+      - esp32evse.autoupdate:
+          id: evse_state
+          period: 0
+```
+
 

--- a/components/esp32evse/autoupdate_action.py
+++ b/components/esp32evse/autoupdate_action.py
@@ -1,0 +1,54 @@
+"""Automation helpers for ESP32 EVSE subscription updates."""
+
+import esphome.codegen as cg
+import esphome.config_validation as cv
+from esphome import automation
+from esphome.components import binary_sensor, number, sensor, switch, text_sensor
+from esphome.const import CONF_ID, CONF_PERIOD
+
+from . import (
+    ESP32EVSEAutoUpdateAction,
+    get_autoupdate_target,
+)
+
+
+def _autoupdate_target_id(value):
+    """Allow referencing any ESP32 EVSE entity that supports subscriptions."""
+
+    validators = [
+        cv.use_id(text_sensor.TextSensor),
+        cv.use_id(sensor.Sensor),
+        cv.use_id(switch.Switch),
+        cv.use_id(binary_sensor.BinarySensor),
+        cv.use_id(number.Number),
+    ]
+    for validator in validators:
+        try:
+            return validator(value)
+        except cv.Invalid:
+            continue
+    raise cv.Invalid("ID must reference an ESP32 EVSE text sensor, sensor, switch, number, or binary sensor")
+
+
+AUTOUPDATE_ACTION_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ID): _autoupdate_target_id,
+        cv.Required(CONF_PERIOD): cv.templatable(cv.uint32_t),
+    }
+)
+
+
+@automation.register_action("esp32evse.autoupdate", ESP32EVSEAutoUpdateAction, AUTOUPDATE_ACTION_SCHEMA)
+async def esp32evse_autoupdate_to_code(config, action_id, template_arg, args):
+    target = await cg.get_variable(config[CONF_ID])
+    mapping = get_autoupdate_target(target)
+    if mapping is None:
+        raise cv.Invalid(
+            "The referenced entity does not belong to the ESP32 EVSE component or does not expose an AT command"
+        )
+    parent, command = mapping
+    var = cg.new_Pvariable(action_id, template_arg, parent)
+    cg.add(var.set_command(command))
+    period = await cg.templatable(config[CONF_PERIOD], args, cg.uint32)
+    cg.add(var.set_period(period))
+    return var

--- a/components/esp32evse/binary_sensor.py
+++ b/components/esp32evse/binary_sensor.py
@@ -14,7 +14,7 @@ from esphome.components import binary_sensor
 import esphome.config_validation as cv
 from esphome.const import DEVICE_CLASS_CONNECTIVITY, ENTITY_CATEGORY_DIAGNOSTIC
 
-from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
+from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns, register_autoupdate_target
 
 DEPENDENCIES = ["esp32evse"]
 
@@ -69,9 +69,11 @@ async def to_code(config):
         sens = await binary_sensor.new_binary_sensor(pending_config)
         await cg.register_parented(sens, config[CONF_ESP32EVSE_ID])
         cg.add(parent.set_pending_authorization_binary_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+PENDAUTH?")
     if wifi_config := config.get(CONF_WIFI_CONNECTED):
         # Track Wi-Fi connectivity so operators can detect when the charger
         # falls offline without looking at the controller's web UI.
         sens = await binary_sensor.new_binary_sensor(wifi_config)
         await cg.register_parented(sens, config[CONF_ESP32EVSE_ID])
         cg.add(parent.set_wifi_connected_binary_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+WIFISTACONN?")

--- a/components/esp32evse/number.py
+++ b/components/esp32evse/number.py
@@ -18,7 +18,7 @@ from esphome.const import (
     UNIT_WATT,
 )
 
-from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
+from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns, register_autoupdate_target
 
 DEPENDENCIES = ["esp32evse"]
 
@@ -238,3 +238,4 @@ async def to_code(config):
         # still speaking the correct serial protocol.
         cg.add(num.set_multiplier(multiplier))
         cg.add(getattr(parent, meta["setter"])(num))
+        register_autoupdate_target(parent, num, meta["command"])

--- a/components/esp32evse/sensor.py
+++ b/components/esp32evse/sensor.py
@@ -31,7 +31,7 @@ try:
 except ImportError:
     from esphome.const import UNIT_WATT_HOURS as UNIT_WATT_HOUR
 
-from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent
+from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, register_autoupdate_target
 
 DEPENDENCIES = ["esp32evse"]
 
@@ -207,54 +207,71 @@ async def to_code(config):
         # Report the highest measured board temperature for diagnostics.
         sens = await sensor.new_sensor(temperature_high_config)
         cg.add(parent.set_temperature_high_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+TEMP?")
     elif temperature_config := config.get(CONF_TEMPERATURE):
         # Backwards compatibility: treat a single temperature sensor as the
         # "high" reading so existing configurations keep working.
         sens = await sensor.new_sensor(temperature_config)
         cg.add(parent.set_temperature_high_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+TEMP?")
     if temperature_low_config := config.get(CONF_TEMPERATURE_LOW):
         # The lower temperature probe is optional but useful for thermal trends.
         sens = await sensor.new_sensor(temperature_low_config)
         cg.add(parent.set_temperature_low_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+TEMP?")
     if power_config := config.get(CONF_EMETER_POWER):
         sens = await sensor.new_sensor(power_config)
         cg.add(parent.set_emeter_power_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+EMETERPOWER?")
     if session_config := config.get(CONF_EMETER_SESSION_TIME):
         sens = await sensor.new_sensor(session_config)
         cg.add(parent.set_emeter_session_time_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+EMETERSESTIME?")
     if charging_config := config.get(CONF_EMETER_CHARGING_TIME):
         sens = await sensor.new_sensor(charging_config)
         cg.add(parent.set_emeter_charging_time_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+EMETERCHTIME?")
     if heap_used_config := config.get(CONF_HEAP_USED):
         sens = await sensor.new_sensor(heap_used_config)
         cg.add(parent.set_heap_used_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+HEAP?")
     if heap_total_config := config.get(CONF_HEAP_TOTAL):
         sens = await sensor.new_sensor(heap_total_config)
         cg.add(parent.set_heap_total_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+HEAP?")
     if energy_config := config.get(CONF_ENERGY_CONSUMPTION):
         sens = await sensor.new_sensor(energy_config)
         cg.add(parent.set_energy_consumption_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+EMETERCONSUM?")
     if total_energy_config := config.get(CONF_TOTAL_ENERGY_CONSUMPTION):
         sens = await sensor.new_sensor(total_energy_config)
         cg.add(parent.set_total_energy_consumption_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+EMETERTOTCONSUM?")
     if voltage_l1_config := config.get(CONF_VOLTAGE_L1):
         sens = await sensor.new_sensor(voltage_l1_config)
         cg.add(parent.set_voltage_l1_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+EMETERVOLTAGE?")
     if voltage_l2_config := config.get(CONF_VOLTAGE_L2):
         sens = await sensor.new_sensor(voltage_l2_config)
         cg.add(parent.set_voltage_l2_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+EMETERVOLTAGE?")
     if voltage_l3_config := config.get(CONF_VOLTAGE_L3):
         sens = await sensor.new_sensor(voltage_l3_config)
         cg.add(parent.set_voltage_l3_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+EMETERVOLTAGE?")
     if current_l1_config := config.get(CONF_CURRENT_L1):
         sens = await sensor.new_sensor(current_l1_config)
         cg.add(parent.set_current_l1_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+EMETERCURRENT?")
     if current_l2_config := config.get(CONF_CURRENT_L2):
         sens = await sensor.new_sensor(current_l2_config)
         cg.add(parent.set_current_l2_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+EMETERCURRENT?")
     if current_l3_config := config.get(CONF_CURRENT_L3):
         sens = await sensor.new_sensor(current_l3_config)
         cg.add(parent.set_current_l3_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+EMETERCURRENT?")
     if wifi_rssi_config := config.get(CONF_WIFI_RSSI):
         sens = await sensor.new_sensor(wifi_rssi_config)
         cg.add(parent.set_wifi_rssi_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+WIFISTACONN?")

--- a/components/esp32evse/switch.py
+++ b/components/esp32evse/switch.py
@@ -7,7 +7,7 @@ from esphome.components import switch
 import esphome.config_validation as cv
 from esphome.const import ENTITY_CATEGORY_CONFIG
 
-from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
+from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns, register_autoupdate_target
 
 DEPENDENCIES = ["esp32evse"]
 
@@ -64,11 +64,14 @@ async def to_code(config):
         sw = await switch.new_switch(enable_config)
         await cg.register_parented(sw, config[CONF_ESP32EVSE_ID])
         cg.add(parent.set_enable_switch(sw))
+        register_autoupdate_target(parent, sw, "AT+ENABLE?")
     if available_config := config.get(CONF_AVAILABLE):
         sw = await switch.new_switch(available_config)
         await cg.register_parented(sw, config[CONF_ESP32EVSE_ID])
         cg.add(parent.set_available_switch(sw))
+        register_autoupdate_target(parent, sw, "AT+AVAILABLE?")
     if req_auth_config := config.get(CONF_REQUEST_AUTHORIZATION):
         sw = await switch.new_switch(req_auth_config)
         await cg.register_parented(sw, config[CONF_ESP32EVSE_ID])
         cg.add(parent.set_request_authorization_switch(sw))
+        register_autoupdate_target(parent, sw, "AT+REQAUTH?")

--- a/components/esp32evse/text_sensor.py
+++ b/components/esp32evse/text_sensor.py
@@ -7,7 +7,7 @@ from esphome.components import text_sensor
 import esphome.config_validation as cv
 from esphome.const import ENTITY_CATEGORY_DIAGNOSTIC
 
-from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent
+from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, register_autoupdate_target
 
 DEPENDENCIES = ["esp32evse"]
 
@@ -82,30 +82,40 @@ async def to_code(config):
     if state_config := config.get(CONF_STATE):
         sens = await text_sensor.new_text_sensor(state_config)
         cg.add(parent.set_state_text_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+STATE?")
     if chip_config := config.get(CONF_CHIP):
         sens = await text_sensor.new_text_sensor(chip_config)
         cg.add(parent.set_chip_text_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+CHIP?")
     if version_config := config.get(CONF_VERSION):
         sens = await text_sensor.new_text_sensor(version_config)
         cg.add(parent.set_version_text_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+VER?")
     if idf_version_config := config.get(CONF_IDF_VERSION):
         sens = await text_sensor.new_text_sensor(idf_version_config)
         cg.add(parent.set_idf_version_text_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+IDFVER?")
     if build_time_config := config.get(CONF_BUILD_TIME):
         sens = await text_sensor.new_text_sensor(build_time_config)
         cg.add(parent.set_build_time_text_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+BUILDTIME?")
     if device_time_config := config.get(CONF_DEVICE_TIME):
         sens = await text_sensor.new_text_sensor(device_time_config)
         cg.add(parent.set_device_time_text_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+TIME?")
     if wifi_ssid_config := config.get(CONF_WIFI_STA_SSID):
         sens = await text_sensor.new_text_sensor(wifi_ssid_config)
         cg.add(parent.set_wifi_sta_ssid_text_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+WIFISTACFG?")
     if wifi_ip_config := config.get(CONF_WIFI_STA_IP):
         sens = await text_sensor.new_text_sensor(wifi_ip_config)
         cg.add(parent.set_wifi_sta_ip_text_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+WIFISTAIP?")
     if wifi_mac_config := config.get(CONF_WIFI_STA_MAC):
         sens = await text_sensor.new_text_sensor(wifi_mac_config)
         cg.add(parent.set_wifi_sta_mac_text_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+WIFISTAMAC?")
     if device_name_config := config.get(CONF_DEVICE_NAME):
         sens = await text_sensor.new_text_sensor(device_name_config)
         cg.add(parent.set_device_name_text_sensor(sens))
+        register_autoupdate_target(parent, sens, "AT+DEVNAME?")


### PR DESCRIPTION
## Summary
- add an `esp32evse.autoupdate` automation action that subscribes/unsubscribes to EVSE AT feeds using entity IDs
- register the subscription command for every ESP32 EVSE text sensor, sensor, switch, number, and binary sensor so the action can resolve the correct AT command
- document the new action in the README for easy reference

## Testing
- python -m compileall components/esp32evse


------
https://chatgpt.com/codex/tasks/task_e_68d59139308c8327bf41f4f5c95f1b3f