### PR TITLE
Fix autoupdate registry to handle MockObj keys

### DIFF
--- a/components/esp32evse/__init__.py
+++ b/components/esp32evse/__init__.py
@@ -103,13 +103,21 @@ def register_autoupdate_target(component, entity, command):
     target = _normalize_subscription_target(command)
     if target is None:
         return
-    _AUTOUPDATE_REGISTRY[entity] = (component, target)
+    # ``entity`` is a ``cg.Pvariable`` instance during normal code generation
+    # but ESPHome swaps in a lightweight ``MockObj`` during configuration
+    # validation.  ``MockObj`` intentionally disables ``__hash__`` so that it
+    # behaves like a regular Python object, which means we cannot use it as a
+    # dictionary key directly.  Instead, stash the registration against the
+    # object's identity.  ``id()`` is stable for the lifetime of the object and
+    # works for both the mock placeholders and the final ``Expression``
+    # instances created during code generation.
+    _AUTOUPDATE_REGISTRY[id(entity)] = (component, target)
 
 
 def get_autoupdate_target(entity):
     """Return the component/command pair for the given entity, if registered."""
 
-    return _AUTOUPDATE_REGISTRY.get(entity)
+    return _AUTOUPDATE_REGISTRY.get(id(entity))
 
 
 # Register automation helpers that depend on the symbols defined above.


### PR DESCRIPTION
## Summary
- store autoupdate registry entries keyed by the object's identity instead of the object itself
- explain why MockObj instances cannot be used as dictionary keys during validation
- ensure autoupdate lookups succeed for both validation mocks and generated expressions

## Testing
- esphome compile esphome.yaml *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5950c6c808327916228cfed2fa46e