### PR TITLE
Expand freshness tracking across ESP32EVSE entities

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Configure the UART as per ESPHome docs, and instantiate the EVSE component and l
 esp32evse:
   id: evse
   uart_id: evse_uart
+  # Optional: adjust how often the component polls the charger (10s–10min).
+  update_interval: 60s
 ```
 
 ## Entities exposed


### PR DESCRIPTION
## Summary
- allow overriding the component update_interval in YAML while enforcing a 10s–10min range
- clamp the runtime poll skipper to the validated bounds and expose the value in dump_config
- document the optional update_interval knob in the README example
- extend freshness-slot coverage so all polled ESP32EVSE entities can skip redundant updates when subscription data is fresh

## Testing
- python -m compileall components/esp32evse

------
https://chatgpt.com/codex/tasks/task_e_68d63378568c832796e767c8e6c4293b