### PR TITLE
Add automation wrappers for EVSE subscription commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,33 +207,32 @@ text_sensor:
 
 ### Using generic AT subscriptions from YAML
 
-The component exposes helper methods so you can trigger `AT+SUB` / `AT+UNSUB`
-commands directly from ESPHome lambdas. This allows custom subscriptions beyond
-ESPHome's built-in update period. Check out the [AT Commands documentation](https://github.com/dzurikmiroslav/esp32-evse/wiki/AT-commands)
+The component now exposes dedicated automation actions that wrap the `AT+SUB`
+and `AT+UNSUB` commands. They let you enable high-frequency updates without
+having to remember the raw AT command names. Check out the
+[AT Commands documentation](https://github.com/dzurikmiroslav/esp32-evse/wiki/AT-commands)
 for details.
 
-In the example below, we enable autoupdate of the ``emeter_power`` entity every 1000ms, pushed from the EVSE:
+To subscribe the ``emeter_power`` sensor to 1000 ms push updates:
 
 ```yaml
     on_press:
-      - lambda: |-
-          id(evse).at_sub("\"+EMETERPOWER\"", 1000);
+      - esp32evse.emeter_power.subscribe: 1000
 ```
 
-Here we disable it:
+Provide ``0`` to stop receiving updates for the same entity:
 
 ```yaml
     on_press:
-      - lambda: |-
-          id(evse).at_unsub("\"+EMETERPOWER\"");
+      - esp32evse.emeter_power.subscribe: 0
 ```
 
-Passing an empty string to `at_unsub()` sends `AT+UNSUB=""` which clears all active subscriptions for all entities:
+And use ``esp32evse.unsubscribe_all`` to clear every active subscription in one
+shot:
 
 ```yaml
     on_press:
-      - lambda: |-
-          id(evse).at_unsub("");
+      - esp32evse.unsubscribe_all:
 ```
 
 

--- a/components/esp32evse/__init__.py
+++ b/components/esp32evse/__init__.py
@@ -8,6 +8,7 @@ why each block exists and how it fits within ESPHome's build pipeline.
 
 # Bring in the ESPHome code generation helpers so we can describe the C++ class
 # hierarchy that backs the component at compile time.
+import esphome.automation as automation
 import esphome.codegen as cg
 # Provide validation utilities to make sure user supplied YAML configuration is
 # structurally correct before we attempt to generate any C++ code.
@@ -25,6 +26,13 @@ DEPENDENCIES = ["uart"]
 CODEOWNERS = ["@nagyrobi"]
 
 esp32evse_ns = cg.esphome_ns.namespace("esp32evse")
+# Automation helpers exposed by this integration.
+ESP32EVSEManagedSubscriptionAction = esp32evse_ns.class_(
+    "ESP32EVSEManagedSubscriptionAction", automation.Action
+)
+ESP32EVSEUnsubscribeAllAction = esp32evse_ns.class_(
+    "ESP32EVSEUnsubscribeAllAction", automation.Action
+)
 # Declare the C++ class that implements the logic.  It inherits from
 # ``PollingComponent`` so ESPHome regularly calls ``update`` and from
 # ``UARTDevice`` so it can talk to the EVSE controller over serial.
@@ -36,6 +44,8 @@ CONF_ESP32EVSE_ID = "esp32evse_id"
 
 MIN_UPDATE_INTERVAL_MS = 10_000
 MAX_UPDATE_INTERVAL_MS = 600_000
+
+CONF_PERIOD = "period"
 
 
 def _clamp_update_interval(config):
@@ -87,3 +97,91 @@ async def to_code(config):
     # Finally, bind the component to the configured UART bus so serial
     # communication with the EVSE controller is possible.
     await uart.register_uart_device(var, config)
+
+
+_SUBSCRIPTION_TARGETS = {
+    # Text sensors
+    "state": '"+STATE"',
+    "chip": '"+CHIP"',
+    "version": '"+VER"',
+    "idf_version": '"+IDFVER"',
+    "build_time": '"+BUILDTIME"',
+    "device_time": '"+TIME"',
+    "wifi_sta_ssid": '"+WIFISTACFG"',
+    "wifi_sta_ip": '"+WIFISTAIP"',
+    "wifi_sta_mac": '"+WIFISTAMAC"',
+    "device_name": '"+DEVNAME"',
+    # Switches
+    "enable": '"+ENABLE"',
+    "available": '"+AVAILABLE"',
+    "request_authorization": '"+REQAUTH"',
+    # Sensors
+    "temperature": '"+TEMP"',
+    "temperature_high": '"+TEMP"',
+    "temperature_low": '"+TEMP"',
+    "emeter_power": '"+EMETERPOWER"',
+    "emeter_session_time": '"+EMETERSESTIME"',
+    "emeter_charging_time": '"+EMETERCHTIME"',
+    "heap_used": '"+HEAP"',
+    "heap_total": '"+HEAP"',
+    "energy_consumption": '"+EMETERCONSUM"',
+    "total_energy_consumption": '"+EMETERTOTCONSUM"',
+    "voltage_l1": '"+EMETERVOLTAGE"',
+    "voltage_l2": '"+EMETERVOLTAGE"',
+    "voltage_l3": '"+EMETERVOLTAGE"',
+    "current_l1": '"+EMETERCURRENT"',
+    "current_l2": '"+EMETERCURRENT"',
+    "current_l3": '"+EMETERCURRENT"',
+    "wifi_rssi": '"+WIFISTACONN"',
+    # Binary sensors
+    "pending_authorization": '"+PENDAUTH"',
+    "wifi_connected": '"+WIFISTACONN"',
+    # Numbers
+    "charging_current": '"+CHCUR"',
+    "default_charging_current": '"+DEFCHCUR"',
+    "maximum_charging_current": '"+MAXCHCUR"',
+    "consumption_limit": '"+CONSUMLIM"',
+    "default_consumption_limit": '"+DEFCONSUMLIM"',
+    "charging_time_limit": '"+CHTIMELIM"',
+    "default_charging_time_limit": '"+DEFCHTIMELIM"',
+    "under_power_limit": '"+UNDERPOWERLIM"',
+    "default_under_power_limit": '"+DEFUNDERPOWERLIM"',
+}
+
+_SUBSCRIPTION_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
+        cv.Required(CONF_PERIOD): cv.templatable(cv.uint32_t),
+    }
+)
+
+
+def _register_subscription_action(name: str, command: str) -> None:
+    """Expose an ``esp32evse.<entity>.subscribe`` automation action."""
+
+    @automation.register_action(
+        f"esp32evse.{name}.subscribe",
+        ESP32EVSEManagedSubscriptionAction,
+        _SUBSCRIPTION_SCHEMA,
+    )
+    async def subscription_action_to_code(config, action_id, template_arg, args, *, _command=command):
+        parent = await cg.get_variable(config[CONF_ESP32EVSE_ID])
+        var = cg.new_Pvariable(action_id, template_arg, parent)
+        cg.add(var.set_command(_command))
+        period = await cg.templatable(config[CONF_PERIOD], args, cg.uint32)
+        cg.add(var.set_period(period))
+        return var
+
+
+for _name, _command in _SUBSCRIPTION_TARGETS.items():
+    _register_subscription_action(_name, _command)
+
+
+@automation.register_action(
+    "esp32evse.unsubscribe_all",
+    ESP32EVSEUnsubscribeAllAction,
+    cv.Schema({cv.GenerateID(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent)}),
+)
+async def unsubscribe_all_to_code(config, action_id, template_arg, args):
+    parent = await cg.get_variable(config[CONF_ESP32EVSE_ID])
+    return cg.new_Pvariable(action_id, template_arg, parent)

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -10,6 +10,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
@@ -32,6 +33,9 @@ class ESP32EVSEResetButton;
 class ESP32EVSEAuthorizeButton;
 class ESP32EVSEPendingAuthorizationBinarySensor;
 class ESP32EVSEWifiConnectedBinarySensor;
+
+class ESP32EVSEManagedSubscriptionAction;
+class ESP32EVSEUnsubscribeAllAction;
 
 // Main component class that orchestrates communication with the EVSE controller
 // and fans out the resulting state to the various ESPHome entities registered
@@ -418,6 +422,41 @@ class ESP32EVSEPendingAuthorizationBinarySensor
 
 class ESP32EVSEWifiConnectedBinarySensor : public binary_sensor::BinarySensor,
                                            public Parented<ESP32EVSEComponent> {};
+
+template<typename... Ts>
+class ESP32EVSEManagedSubscriptionAction : public Action<Ts...> {
+ public:
+  explicit ESP32EVSEManagedSubscriptionAction(ESP32EVSEComponent *parent) : parent_(parent) {}
+  TEMPLATABLE_VALUE(uint32_t, period)
+
+  void set_command(const std::string &command) { command_ = command; }
+
+  void play(Ts... x) {
+    if (command_.empty())
+      return;
+    uint32_t period = this->period_.value(x...);
+    if (period == 0) {
+      this->parent_->at_unsub(command_);
+    } else {
+      this->parent_->at_sub(command_, period);
+    }
+  }
+
+ protected:
+  ESP32EVSEComponent *parent_;
+  std::string command_;
+};
+
+template<typename... Ts>
+class ESP32EVSEUnsubscribeAllAction : public Action<Ts...> {
+ public:
+  explicit ESP32EVSEUnsubscribeAllAction(ESP32EVSEComponent *parent) : parent_(parent) {}
+
+  void play(Ts... x) { this->parent_->at_unsub(); }
+
+ protected:
+  ESP32EVSEComponent *parent_;
+};
 
 }  // namespace esp32evse
 }  // namespace esphome


### PR DESCRIPTION
## Summary
- add automation actions that wrap AT+SUB for every exposed ESP32 EVSE entity and accept 0 to unsubscribe
- expose a component-level action to clear all subscriptions and update the documentation accordingly

## Testing
- python -m compileall components/esp32evse

------
https://chatgpt.com/codex/tasks/task_e_68d65818e9648327a49c1fb229b6943d