### PR TITLE
Fix ESP32 EVSE action registration order

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,33 +207,34 @@ text_sensor:
 
 ### Using generic AT subscriptions from YAML
 
-The component exposes helper methods so you can trigger `AT+SUB` / `AT+UNSUB`
-commands directly from ESPHome lambdas. This allows custom subscriptions beyond
-ESPHome's built-in update period. Check out the [AT Commands documentation](https://github.com/dzurikmiroslav/esp32-evse/wiki/AT-commands)
+The component now exposes dedicated automation actions that wrap the `AT+SUB`
+and `AT+UNSUB` commands. They let you enable high-frequency updates without
+having to remember the raw AT command names. Check out the
+[AT Commands documentation](https://github.com/dzurikmiroslav/esp32-evse/wiki/AT-commands)
 for details.
 
-In the example below, we enable autoupdate of the ``emeter_power`` entity every 1000ms, pushed from the EVSE:
+To subscribe the ``emeter_power`` sensor to push updates every second (use any
+valid [ESPHome time](https://esphome.io/guides/configuration-types/#config-time)
+expression or a raw millisecond count):
 
 ```yaml
     on_press:
-      - lambda: |-
-          id(evse).at_sub("\"+EMETERPOWER\"", 1000);
+      - esp32evse.emeter_power.subscribe: 1s
 ```
 
-Here we disable it:
+Provide ``0`` to stop receiving updates for the same entity:
 
 ```yaml
     on_press:
-      - lambda: |-
-          id(evse).at_unsub("\"+EMETERPOWER\"");
+      - esp32evse.emeter_power.subscribe: 0
 ```
 
-Passing an empty string to `at_unsub()` sends `AT+UNSUB=""` which clears all active subscriptions for all entities:
+And use ``esp32evse.unsubscribe_all`` to clear every active subscription in one
+shot (add ``esp32evse_id: <id>`` if you host multiple EVSE components):
 
 ```yaml
     on_press:
-      - lambda: |-
-          id(evse).at_unsub("");
+      - esp32evse.unsubscribe_all:
 ```
 
 

--- a/components/esp32evse/__init__.py
+++ b/components/esp32evse/__init__.py
@@ -8,6 +8,7 @@ why each block exists and how it fits within ESPHome's build pipeline.
 
 # Bring in the ESPHome code generation helpers so we can describe the C++ class
 # hierarchy that backs the component at compile time.
+import esphome.automation as automation
 import esphome.codegen as cg
 # Provide validation utilities to make sure user supplied YAML configuration is
 # structurally correct before we attempt to generate any C++ code.
@@ -31,11 +32,60 @@ esp32evse_ns = cg.esphome_ns.namespace("esp32evse")
 ESP32EVSEComponent = esp32evse_ns.class_(
     "ESP32EVSEComponent", cg.PollingComponent, uart.UARTDevice
 )
+# Automation helpers exposed by this integration.
+ESP32EVSEManagedSubscriptionAction = esp32evse_ns.class_(
+    "ESP32EVSEManagedSubscriptionAction",
+    automation.Action,
+    cg.Parented.template(ESP32EVSEComponent),
+)
+ESP32EVSEUnsubscribeAllAction = esp32evse_ns.class_(
+    "ESP32EVSEUnsubscribeAllAction",
+    automation.Action,
+    cg.Parented.template(ESP32EVSEComponent),
+)
 
 CONF_ESP32EVSE_ID = "esp32evse_id"
 
 MIN_UPDATE_INTERVAL_MS = 10_000
 MAX_UPDATE_INTERVAL_MS = 600_000
+
+CONF_PERIOD = "period"
+
+_REGISTERED_COMPONENT_IDS: list[cg.ID] = []
+
+
+def _normalize_subscription_period(value):
+    """Accept integers (milliseconds) or config-time durations."""
+
+    if isinstance(value, cv.Lambda):
+        return value
+    if isinstance(value, cv.TimePeriod):
+        return value
+    if isinstance(value, int):
+        value = cv.uint32_t(value)
+        return cv.TimePeriod(milliseconds=value)
+    if isinstance(value, float):
+        raise cv.Invalid("period must be specified as whole milliseconds")
+    return cv.positive_time_period_milliseconds(value)
+
+
+def _resolve_parent_id(config):
+    component_id = config.get(CONF_ESP32EVSE_ID)
+    if component_id is not None:
+        return component_id
+    if len(_REGISTERED_COMPONENT_IDS) == 1:
+        return _REGISTERED_COMPONENT_IDS[0]
+    raise cv.Invalid(
+        "esp32evse_id must be specified when multiple ESP32 EVSE components are configured"
+    )
+
+
+def _validate_unsubscribe_all_config(value):
+    if value is None:
+        value = {}
+    elif not isinstance(value, dict):
+        value = {CONF_ESP32EVSE_ID: value}
+    return cv.Schema({cv.Optional(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent)})(value)
 
 
 def _clamp_update_interval(config):
@@ -87,3 +137,99 @@ async def to_code(config):
     # Finally, bind the component to the configured UART bus so serial
     # communication with the EVSE controller is possible.
     await uart.register_uart_device(var, config)
+    if config[CONF_ID] not in _REGISTERED_COMPONENT_IDS:
+        _REGISTERED_COMPONENT_IDS.append(config[CONF_ID])
+
+
+_SUBSCRIPTION_TARGETS = {
+    # Text sensors
+    "state": '"+STATE"',
+    "chip": '"+CHIP"',
+    "version": '"+VER"',
+    "idf_version": '"+IDFVER"',
+    "build_time": '"+BUILDTIME"',
+    "device_time": '"+TIME"',
+    "wifi_sta_ssid": '"+WIFISTACFG"',
+    "wifi_sta_ip": '"+WIFISTAIP"',
+    "wifi_sta_mac": '"+WIFISTAMAC"',
+    "device_name": '"+DEVNAME"',
+    # Switches
+    "enable": '"+ENABLE"',
+    "available": '"+AVAILABLE"',
+    "request_authorization": '"+REQAUTH"',
+    # Sensors
+    "temperature": '"+TEMP"',
+    "temperature_high": '"+TEMP"',
+    "temperature_low": '"+TEMP"',
+    "emeter_power": '"+EMETERPOWER"',
+    "emeter_session_time": '"+EMETERSESTIME"',
+    "emeter_charging_time": '"+EMETERCHTIME"',
+    "heap_used": '"+HEAP"',
+    "heap_total": '"+HEAP"',
+    "energy_consumption": '"+EMETERCONSUM"',
+    "total_energy_consumption": '"+EMETERTOTCONSUM"',
+    "voltage_l1": '"+EMETERVOLTAGE"',
+    "voltage_l2": '"+EMETERVOLTAGE"',
+    "voltage_l3": '"+EMETERVOLTAGE"',
+    "current_l1": '"+EMETERCURRENT"',
+    "current_l2": '"+EMETERCURRENT"',
+    "current_l3": '"+EMETERCURRENT"',
+    "wifi_rssi": '"+WIFISTACONN"',
+    # Binary sensors
+    "pending_authorization": '"+PENDAUTH"',
+    "wifi_connected": '"+WIFISTACONN"',
+    # Numbers
+    "charging_current": '"+CHCUR"',
+    "default_charging_current": '"+DEFCHCUR"',
+    "maximum_charging_current": '"+MAXCHCUR"',
+    "consumption_limit": '"+CONSUMLIM"',
+    "default_consumption_limit": '"+DEFCONSUMLIM"',
+    "charging_time_limit": '"+CHTIMELIM"',
+    "default_charging_time_limit": '"+DEFCHTIMELIM"',
+    "under_power_limit": '"+UNDERPOWERLIM"',
+    "default_under_power_limit": '"+DEFUNDERPOWERLIM"',
+}
+
+_SUBSCRIPTION_SCHEMA = automation.maybe_conf(
+    CONF_PERIOD,
+    cv.Schema(
+        {
+            cv.Optional(CONF_ESP32EVSE_ID): cv.use_id(ESP32EVSEComponent),
+            cv.Required(CONF_PERIOD): cv.templatable(_normalize_subscription_period),
+        }
+    ),
+)
+
+
+def _register_subscription_action(name: str, command: str) -> None:
+    """Expose an ``esp32evse.<entity>.subscribe`` automation action."""
+
+    @automation.register_action(
+        f"esp32evse.{name}.subscribe",
+        ESP32EVSEManagedSubscriptionAction,
+        _SUBSCRIPTION_SCHEMA,
+    )
+    async def subscription_action_to_code(config, action_id, template_arg, args, *, _command=command):
+        component_id = _resolve_parent_id(config)
+        var = cg.new_Pvariable(action_id, template_arg)
+        await cg.register_parented(var, component_id)
+        cg.add(var.set_command(_command))
+        period = await cg.templatable(config[CONF_PERIOD], args, cg.uint32)
+        cg.add(var.set_period(period))
+        return var
+
+
+for _name, _command in _SUBSCRIPTION_TARGETS.items():
+    _register_subscription_action(_name, _command)
+
+
+@automation.register_action(
+    "esp32evse.unsubscribe_all",
+    ESP32EVSEUnsubscribeAllAction,
+    _validate_unsubscribe_all_config,
+)
+async def unsubscribe_all_to_code(config, action_id, template_arg, args):
+    component_id = _resolve_parent_id(config)
+    var = cg.new_Pvariable(action_id, template_arg)
+    await cg.register_parented(var, component_id)
+    return var

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -10,6 +10,7 @@
 #include "esphome/components/switch/switch.h"
 #include "esphome/components/text_sensor/text_sensor.h"
 #include "esphome/components/uart/uart.h"
+#include "esphome/core/automation.h"
 #include "esphome/core/component.h"
 #include "esphome/core/defines.h"
 #include "esphome/core/hal.h"
@@ -32,6 +33,9 @@ class ESP32EVSEResetButton;
 class ESP32EVSEAuthorizeButton;
 class ESP32EVSEPendingAuthorizationBinarySensor;
 class ESP32EVSEWifiConnectedBinarySensor;
+
+class ESP32EVSEManagedSubscriptionAction;
+class ESP32EVSEUnsubscribeAllAction;
 
 // Main component class that orchestrates communication with the EVSE controller
 // and fans out the resulting state to the various ESPHome entities registered
@@ -418,6 +422,39 @@ class ESP32EVSEPendingAuthorizationBinarySensor
 
 class ESP32EVSEWifiConnectedBinarySensor : public binary_sensor::BinarySensor,
                                            public Parented<ESP32EVSEComponent> {};
+
+template<typename... Ts>
+class ESP32EVSEManagedSubscriptionAction : public Action<Ts...>, public Parented<ESP32EVSEComponent> {
+ public:
+  TEMPLATABLE_VALUE(uint32_t, period)
+
+  void set_command(const std::string &command) { command_ = command; }
+
+  void play(Ts... x) {
+    auto *parent = this->parent_;
+    if (parent == nullptr || command_.empty())
+      return;
+    uint32_t period = this->period_.value(x...);
+    if (period == 0) {
+      parent->at_unsub(command_);
+    } else {
+      parent->at_sub(command_, period);
+    }
+  }
+
+ protected:
+  std::string command_;
+};
+
+template<typename... Ts>
+class ESP32EVSEUnsubscribeAllAction : public Action<Ts...>, public Parented<ESP32EVSEComponent> {
+ public:
+  void play(Ts... x) {
+    if (this->parent_ == nullptr)
+      return;
+    this->parent_->at_unsub();
+  }
+};
 
 }  // namespace esp32evse
 }  // namespace esphome


### PR DESCRIPTION
## Summary
- define ESP32EVSEComponent before declaring automation action helpers so Parented template resolution succeeds at import time

## Testing
- python -m compileall components/esp32evse

------
https://chatgpt.com/codex/tasks/task_e_68d65818e9648327a49c1fb229b6943d