### PR TITLE
Deduplicate shared subscription actions and document 'never' unsubscribes

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,11 +222,11 @@ expression or a raw millisecond count):
       - esp32evse.emeter_power.subscribe: 1s
 ```
 
-Provide ``0`` to stop receiving updates for the same entity:
+Provide ``never`` to stop receiving updates for the same entity:
 
 ```yaml
     on_press:
-      - esp32evse.emeter_power.subscribe: 0
+      - esp32evse.emeter_power.subscribe: never
 ```
 
 And use ``esp32evse.unsubscribe_all`` to clear every active subscription in one
@@ -236,5 +236,11 @@ shot (add ``esp32evse_id: <id>`` if you host multiple EVSE components):
     on_press:
       - esp32evse.unsubscribe_all:
 ```
+
+> **Note:** A few subscription actions control multiple sensors because the EVSE
+> reports them together. For example, ``esp32evse.temperature.subscribe`` drives
+> both ``temperature_high`` and ``temperature_low``, ``esp32evse.heap.subscribe``
+> updates ``heap_used`` and ``heap_total``, and the ``esp32evse.voltage`` and
+> ``esp32evse.current`` actions publish all phase-specific measurements.
 
 

--- a/components/esp32evse/__init__.py
+++ b/components/esp32evse/__init__.py
@@ -60,13 +60,25 @@ def _normalize_subscription_period(value):
     if isinstance(value, cv.Lambda):
         return value
     if isinstance(value, cv.TimePeriod):
+        if getattr(value, "is_never", False):
+            return value
+        total_ms = getattr(value, "total_milliseconds", None)
+        if total_ms == 0:
+            raise cv.Invalid("period must be greater than 0; use 'never' to unsubscribe")
         return value
     if isinstance(value, int):
         value = cv.uint32_t(value)
+        if value == 0:
+            raise cv.Invalid("period must be greater than 0; use 'never' to unsubscribe")
         return cv.TimePeriod(milliseconds=value)
     if isinstance(value, float):
         raise cv.Invalid("period must be specified as whole milliseconds")
-    return cv.positive_time_period_milliseconds(value)
+    period = cv.positive_time_period_milliseconds(value)
+    if isinstance(period, cv.TimePeriod):
+        total_ms = getattr(period, "total_milliseconds", None)
+        if total_ms == 0 and not getattr(period, "is_never", False):
+            raise cv.Invalid("period must be greater than 0; use 'never' to unsubscribe")
+    return period
 
 
 def _resolve_parent_id(config):
@@ -159,21 +171,14 @@ _SUBSCRIPTION_TARGETS = {
     "request_authorization": '"+REQAUTH"',
     # Sensors
     "temperature": '"+TEMP"',
-    "temperature_high": '"+TEMP"',
-    "temperature_low": '"+TEMP"',
     "emeter_power": '"+EMETERPOWER"',
     "emeter_session_time": '"+EMETERSESTIME"',
     "emeter_charging_time": '"+EMETERCHTIME"',
-    "heap_used": '"+HEAP"',
-    "heap_total": '"+HEAP"',
+    "heap": '"+HEAP"',
     "energy_consumption": '"+EMETERCONSUM"',
     "total_energy_consumption": '"+EMETERTOTCONSUM"',
-    "voltage_l1": '"+EMETERVOLTAGE"',
-    "voltage_l2": '"+EMETERVOLTAGE"',
-    "voltage_l3": '"+EMETERVOLTAGE"',
-    "current_l1": '"+EMETERCURRENT"',
-    "current_l2": '"+EMETERCURRENT"',
-    "current_l3": '"+EMETERCURRENT"',
+    "voltage": '"+EMETERVOLTAGE"',
+    "current": '"+EMETERCURRENT"',
     "wifi_rssi": '"+WIFISTACONN"',
     # Binary sensors
     "pending_authorization": '"+PENDAUTH"',
@@ -216,7 +221,10 @@ def _register_subscription_action(name: str, command: str) -> None:
         cg.add(var.set_command(_command))
         period_config = config[CONF_PERIOD]
         if isinstance(period_config, cv.TimePeriod):
-            period = cg.uint32(period_config.total_milliseconds)
+            if getattr(period_config, "is_never", False):
+                period = cg.uint32(0)
+            else:
+                period = cg.uint32(period_config.total_milliseconds)
         else:
             period = await cg.templatable(period_config, args, cg.uint32)
         cg.add(var.set_period(period))


### PR DESCRIPTION
## Summary
- remove duplicate subscription action registrations for shared AT commands
- validate subscription periods to require `never` instead of zero milliseconds
- document the new `never` usage and note which actions drive multiple sensors

## Testing
- python -m compileall components/esp32evse/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68d66e17633c83278809357ef4ed6aea