### PR TITLE
Handle 'never' subscription periods in automation actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,11 +222,11 @@ expression or a raw millisecond count):
       - esp32evse.emeter_power.subscribe: 1s
 ```
 
-Provide ``0`` to stop receiving updates for the same entity:
+Provide ``never`` to stop receiving updates for the same entity:
 
 ```yaml
     on_press:
-      - esp32evse.emeter_power.subscribe: 0
+      - esp32evse.emeter_power.subscribe: never
 ```
 
 And use ``esp32evse.unsubscribe_all`` to clear every active subscription in one
@@ -236,5 +236,11 @@ shot (add ``esp32evse_id: <id>`` if you host multiple EVSE components):
     on_press:
       - esp32evse.unsubscribe_all:
 ```
+
+> **Note:** A few subscription actions control multiple sensors because the EVSE
+> reports them together. For example, ``esp32evse.temperature.subscribe`` drives
+> both ``temperature_high`` and ``temperature_low``, ``esp32evse.heap.subscribe``
+> updates ``heap_used`` and ``heap_total``, and the ``esp32evse.voltage`` and
+> ``esp32evse.current`` actions publish all phase-specific measurements.
 
 


### PR DESCRIPTION
## Summary
- accept the YAML `never` keyword for subscription periods and translate it to an unsubscribe request
- preserve validation that rejects zero durations in favor of the documented `never` keyword

## Testing
- python -m compileall components/esp32evse/__init__.py

------
https://chatgpt.com/codex/tasks/task_e_68d66e17633c83278809357ef4ed6aea