### PR TITLE
Delay ESP32 EVSE switch state publication until confirmation

### DIFF
--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -1192,23 +1192,20 @@ void ESP32EVSEComponent::request_number_update_(ESP32EVSEChargingCurrentNumber *
 void ESP32EVSEEnableSwitch::write_state(bool state) {
   if (this->parent_ == nullptr)
     return;
-  this->publish_state(state);
   this->parent_->write_enable_state(state);
 }
 
-// Switch implementations optimistically publish their new state and rely on the
-// component callbacks to revert if the EVSE rejects the request.
+// Switch implementations defer publishing their new state until the EVSE
+// acknowledges the change via the component callbacks.
 void ESP32EVSEAvailableSwitch::write_state(bool state) {
   if (this->parent_ == nullptr)
     return;
-  this->publish_state(state);
   this->parent_->write_available_state(state);
 }
 
 void ESP32EVSERequestAuthorizationSwitch::write_state(bool state) {
   if (this->parent_ == nullptr)
     return;
-  this->publish_state(state);
   this->parent_->write_request_authorization_state(state);
 }
 


### PR DESCRIPTION
## Summary
- stop the enable, available, and request authorization switches from publishing their new state immediately
- rely on the EVSE acknowledgement callbacks to update the switch states and document the new behavior

## Testing
- not run (hardware-dependent manual validation required)


------
https://chatgpt.com/codex/tasks/task_e_68d827683bc88327b1fd67352aa6f4ec