### PR TITLE
Delay number state updates until EVSE confirmation

### DIFF
--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -1219,7 +1219,6 @@ void ESP32EVSEChargingCurrentNumber::control(float value) {
   if (this->parent_ == nullptr)
     return;
   float limited = this->parent_->clamp_charging_current_value(this, value);
-  this->publish_state(limited);
   this->parent_->write_number_value(this, limited);
 }
 


### PR DESCRIPTION
## Summary
- remove the optimistic state publish from the charging current number control path so Home Assistant waits for the EVSE response
- rely on the existing publish_scaled_number_ helper to publish the EVSE-reported charging current when the response arrives

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d82824e7948327a9d673d97afe25e3