### PR TITLE
Handle pending EVSE write acknowledgements

### DIFF
--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -257,10 +257,22 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   // Commands are queued while we wait for acknowledgements from the EVSE; this
   // struct tracks their progress and callbacks.
   struct PendingCommand {
+    enum class Type : uint8_t {
+      GENERIC = 0,
+      ENABLE_WRITE,
+      AVAILABLE_WRITE,
+      REQUEST_AUTHORIZATION_WRITE,
+      NUMBER_WRITE,
+    };
+
+    Type type{Type::GENERIC};
     std::string command;
-    std::function<void(bool)> callback;
+    std::function<void(const PendingCommand &, bool)> callback;
     uint32_t start_time{0};
     bool sent{false};
+    bool bool_value{false};
+    ESP32EVSEChargingCurrentNumber *number{nullptr};
+    float scaled_value{std::numeric_limits<float>::quiet_NaN()};
   };
 
   void process_line_(const std::string &line);
@@ -301,7 +313,11 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   void update_default_under_power_limit_(float value);
   void update_pending_authorization_(bool pending);
 
-  bool send_command_(const std::string &command, std::function<void(bool)> callback = nullptr);
+  bool send_command_(const std::string &command,
+                     std::function<void(const PendingCommand &, bool)> callback = nullptr);
+  void queue_pending_command_(PendingCommand pending);
+  bool is_front_sent_write_(PendingCommand::Type type,
+                            ESP32EVSEChargingCurrentNumber *number = nullptr) const;
   void request_number_update_(ESP32EVSEChargingCurrentNumber *number);
   void publish_scaled_number_(ESP32EVSEChargingCurrentNumber *number, float raw_value);
   void publish_text_sensor_state_(text_sensor::TextSensor *sensor, const std::string &state);


### PR DESCRIPTION
## Summary
- extend the pending command metadata so writes know their target type and value
- publish requested switch and number states after acknowledgement while suppressing duplicate subscription updates during the wait

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d82de1355c8327b9b961829f618bb0