### PR TITLE
Rename three-phase meter switch option to three_phase_meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ switch:
       name: "EVSE Available"
     request_authorization:
       name: "EVSE Request Authorization"
+    three_phase_meter:
+      name: "EVSE Three-Phase Meter"
 ```
 
 ### Buttons

--- a/components/esp32evse/__init__.py
+++ b/components/esp32evse/__init__.py
@@ -179,6 +179,7 @@ _SUBSCRIPTION_TARGETS = {
     "enable": '"+ENABLE"',
     "available": '"+AVAILABLE"',
     "request_authorization": '"+REQAUTH"',
+    "three_phase_meter": '"+EMETERTHREEPHASE"',
     # Sensors
     "temperature": '"+TEMP"',
     "emeter_power": '"+EMETERPOWER"',

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -28,6 +28,7 @@ namespace esp32evse {
 class ESP32EVSEEnableSwitch;
 class ESP32EVSEAvailableSwitch;
 class ESP32EVSERequestAuthorizationSwitch;
+class ESP32EVSEEmeterThreePhaseSwitch;
 class ESP32EVSEChargingCurrentNumber;
 class ESP32EVSEResetButton;
 class ESP32EVSEAuthorizeButton;
@@ -83,6 +84,9 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   void set_available_switch(ESP32EVSEAvailableSwitch *sw) { this->available_switch_ = sw; }
   void set_request_authorization_switch(ESP32EVSERequestAuthorizationSwitch *sw) {
     this->request_authorization_switch_ = sw;
+  }
+  void set_emeter_three_phase_switch(ESP32EVSEEmeterThreePhaseSwitch *sw) {
+    this->emeter_three_phase_switch_ = sw;
   }
 
   void set_temperature_high_sensor(sensor::Sensor *sensor) {
@@ -177,6 +181,7 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   void request_device_name_update();
   void request_available_update();
   void request_request_authorization_update();
+  void request_emeter_three_phase_update();
   void request_heap_update();
   void request_energy_consumption_update();
   void request_total_energy_consumption_update();
@@ -197,6 +202,7 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   void write_enable_state(bool enabled);
   void write_available_state(bool available);
   void write_request_authorization_state(bool request);
+  void write_emeter_three_phase_state(bool enabled);
   void write_charging_current(float current);
   void write_number_value(ESP32EVSEChargingCurrentNumber *number, float value);
 
@@ -229,6 +235,7 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
     WIFI_STATUS,
     AVAILABLE,
     REQUEST_AUTHORIZATION,
+    EMETER_THREE_PHASE,
     DEFAULT_CHARGING_CURRENT,
     MAXIMUM_CHARGING_CURRENT,
     CONSUMPTION_LIMIT,
@@ -262,6 +269,7 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
       ENABLE_WRITE,
       AVAILABLE_WRITE,
       REQUEST_AUTHORIZATION_WRITE,
+      EMETER_THREE_PHASE_WRITE,
       NUMBER_WRITE,
     };
 
@@ -301,6 +309,7 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   void update_device_name_(const std::string &name);
   void update_available_(bool available);
   void update_request_authorization_(bool request);
+  void update_emeter_three_phase_(bool enabled);
   void update_heap_(std::optional<uint32_t> heap_used_bytes,
                     std::optional<uint32_t> heap_total_bytes);
   void update_energy_consumption_(float value);
@@ -345,6 +354,7 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   ESP32EVSEEnableSwitch *enable_switch_{nullptr};
   ESP32EVSEAvailableSwitch *available_switch_{nullptr};
   ESP32EVSERequestAuthorizationSwitch *request_authorization_switch_{nullptr};
+  ESP32EVSEEmeterThreePhaseSwitch *emeter_three_phase_switch_{nullptr};
 
   sensor::Sensor *temperature_high_sensor_{nullptr};
   sensor::Sensor *temperature_low_sensor_{nullptr};
@@ -403,6 +413,12 @@ class ESP32EVSEAvailableSwitch : public switch_::Switch, public Parented<ESP32EV
 };
 
 class ESP32EVSERequestAuthorizationSwitch
+    : public switch_::Switch, public Parented<ESP32EVSEComponent> {
+ protected:
+  void write_state(bool state) override;
+};
+
+class ESP32EVSEEmeterThreePhaseSwitch
     : public switch_::Switch, public Parented<ESP32EVSEComponent> {
  protected:
   void write_state(bool state) override;

--- a/components/esp32evse/switch.py
+++ b/components/esp32evse/switch.py
@@ -18,10 +18,14 @@ ESP32EVSEAvailableSwitch = esp32evse_ns.class_("ESP32EVSEAvailableSwitch", switc
 ESP32EVSERequestAuthorizationSwitch = esp32evse_ns.class_(
     "ESP32EVSERequestAuthorizationSwitch", switch.Switch
 )
+ESP32EVSEEmeterThreePhaseSwitch = esp32evse_ns.class_(
+    "ESP32EVSEEmeterThreePhaseSwitch", switch.Switch
+)
 
 CONF_ENABLE = "enable"
 CONF_AVAILABLE = "available"
 CONF_REQUEST_AUTHORIZATION = "request_authorization"
+CONF_THREE_PHASE_METER = "three_phase_meter"
 
 
 CONFIG_SCHEMA = cv.All(
@@ -48,10 +52,17 @@ CONFIG_SCHEMA = cv.All(
                 icon="mdi:hand-back-left-outline",
                 entity_category=ENTITY_CATEGORY_CONFIG,
             ),
+            cv.Optional(CONF_THREE_PHASE_METER): switch.switch_schema(
+                ESP32EVSEEmeterThreePhaseSwitch,
+                icon="mdi:transmission-tower",
+                entity_category=ENTITY_CATEGORY_CONFIG,
+            ),
         }
     ),
     # Avoid generating empty switch groups by requiring at least one entry.
-    cv.has_at_least_one_key(CONF_ENABLE, CONF_AVAILABLE, CONF_REQUEST_AUTHORIZATION),
+    cv.has_at_least_one_key(
+        CONF_ENABLE, CONF_AVAILABLE, CONF_REQUEST_AUTHORIZATION, CONF_THREE_PHASE_METER
+    ),
 )
 
 
@@ -72,3 +83,7 @@ async def to_code(config):
         sw = await switch.new_switch(req_auth_config)
         await cg.register_parented(sw, config[CONF_ESP32EVSE_ID])
         cg.add(parent.set_request_authorization_switch(sw))
+    if three_phase_config := config.get(CONF_THREE_PHASE_METER):
+        sw = await switch.new_switch(three_phase_config)
+        await cg.register_parented(sw, config[CONF_ESP32EVSE_ID])
+        cg.add(parent.set_emeter_three_phase_switch(sw))

--- a/esphome.yaml
+++ b/esphome.yaml
@@ -151,6 +151,8 @@ switch:
       name: "EVSE Request Authorization"
     available:
       name: "EVSE Available"
+    three_phase_meter:
+      name: "EVSE Three-Phase Meter"
 
 # Text sensors carry metadata strings such as firmware details and network
 # identifiers that are useful for diagnostics.


### PR DESCRIPTION
## Summary
- rename the EVSE switch configuration option to `three_phase_meter` and update subscription wiring
- add the new switch to the README and sample `esphome.yaml`

## Testing
- python -m compileall components

------
https://chatgpt.com/codex/tasks/task_e_68db992df4fc832791cd8020f2ff7114