### PR TITLE
Add uptime and charging limit telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ sensor:
       name: "EVSE Heap Used"
     heap_total:
       name: "EVSE Heap Total"
+    uptime:
+      name: "EVSE Uptime"
 ```
 If your installation only uses a single temperature sensor, expose it via the combined ``temperature`` key instead of the individual high/low entries:
 
@@ -95,6 +97,9 @@ If your installation only uses a single temperature sensor, expose it via the co
     temperature:
       name: "EVSE Temperature"
 ```
+
+The optional ``uptime`` sensor surfaces how long the EVSE firmware has been running since the last reboot, which is useful for
+diagnostics and correlating watchdog resets.
 
 ### Switches
 
@@ -134,7 +139,12 @@ binary_sensor:
       name: "EVSE Pending Authorization"
     wifi_connected:
       name: "EVSE Wi-Fi Connected"
+    charging_limit_reached:
+      name: "EVSE Charging Limit Reached"
 ```
+
+The ``charging_limit_reached`` binary sensor turns on when the EVSE stopped charging because a configured limit (time, energy, or
+under-power) was met, allowing automations to react immediately.
 
 ### Numbers
 
@@ -235,5 +245,9 @@ reports them together. For example, ``esp32evse.temperature.subscribe`` drives
 both ``temperature_high`` and ``temperature_low``, ``esp32evse.heap.subscribe``
 updates ``heap_used`` and ``heap_total``, and the ``esp32evse.voltage.subscribe`` and
 ``esp32evse.current.subscribe`` actions publish all phase-specific measurements.
+
+Subscriptions are also available for the new entities: ``esp32evse.uptime.subscribe``
+queries or follows the EVSE uptime, while ``esp32evse.charging_limit_reached.subscribe``
+tracks push notifications when a charging limit trips.
 
 

--- a/components/esp32evse/__init__.py
+++ b/components/esp32evse/__init__.py
@@ -185,6 +185,7 @@ _SUBSCRIPTION_TARGETS = {
     "emeter_power": '"+EMETERPOWER"',
     "emeter_session_time": '"+EMETERSESTIME"',
     "emeter_charging_time": '"+EMETERCHTIME"',
+    "uptime": '"+UPTIME"',
     "heap": '"+HEAP"',
     "energy_consumption": '"+EMETERCONSUM"',
     "total_energy_consumption": '"+EMETERTOTCONSUM"',
@@ -194,6 +195,7 @@ _SUBSCRIPTION_TARGETS = {
     # Binary sensors
     "pending_authorization": '"+PENDAUTH"',
     "wifi_connected": '"+WIFISTACONN"',
+    "charging_limit_reached": '"+LIMREACH"',
     # Numbers
     "charging_current": '"+CHCUR"',
     "default_charging_current": '"+DEFCHCUR"',

--- a/components/esp32evse/sensor.py
+++ b/components/esp32evse/sensor.py
@@ -41,6 +41,7 @@ CONF_TEMPERATURE_LOW = "temperature_low"
 CONF_EMETER_POWER = "emeter_power"
 CONF_EMETER_SESSION_TIME = "emeter_session_time"
 CONF_EMETER_CHARGING_TIME = "emeter_charging_time"
+CONF_UPTIME = "uptime"
 CONF_HEAP_USED = "heap_used"
 CONF_HEAP_TOTAL = "heap_total"
 CONF_ENERGY_CONSUMPTION = "energy_consumption"
@@ -99,6 +100,12 @@ CONFIG_SCHEMA = cv.All(
                 unit_of_measurement=UNIT_SECOND,
                 icon=ICON_TIMER,
                 state_class=STATE_CLASS_MEASUREMENT,
+            ),
+            cv.Optional(CONF_UPTIME): sensor.sensor_schema(
+                unit_of_measurement=UNIT_SECOND,
+                icon=ICON_TIMER,
+                state_class=STATE_CLASS_MEASUREMENT,
+                entity_category=ENTITY_CATEGORY_DIAGNOSTIC,
             ),
             cv.Optional(CONF_HEAP_USED): sensor.sensor_schema(
                 unit_of_measurement="B",
@@ -183,6 +190,7 @@ CONFIG_SCHEMA = cv.All(
         CONF_EMETER_POWER,
         CONF_EMETER_SESSION_TIME,
         CONF_EMETER_CHARGING_TIME,
+        CONF_UPTIME,
         CONF_HEAP_USED,
         CONF_HEAP_TOTAL,
         CONF_ENERGY_CONSUMPTION,
@@ -225,6 +233,9 @@ async def to_code(config):
     if charging_config := config.get(CONF_EMETER_CHARGING_TIME):
         sens = await sensor.new_sensor(charging_config)
         cg.add(parent.set_emeter_charging_time_sensor(sens))
+    if uptime_config := config.get(CONF_UPTIME):
+        sens = await sensor.new_sensor(uptime_config)
+        cg.add(parent.set_uptime_sensor(sens))
     if heap_used_config := config.get(CONF_HEAP_USED):
         sens = await sensor.new_sensor(heap_used_config)
         cg.add(parent.set_heap_used_sensor(sens))


### PR DESCRIPTION
## Summary
- add optional uptime sensor and charging limit reached binary sensor along with subscription hooks
- extend the ESP32 EVSE component to query, parse, and publish AT+UPTIME?/AT+LIMREACH? responses
- document the new entities and their subscription helpers in the integration README

## Testing
- python -m compileall components/esp32evse

------
https://chatgpt.com/codex/tasks/task_e_68e01d53e0d483279f92aedc587957e9