### PR TITLE
Fix ESP32 EVSE ready trigger compatibility

### DIFF
--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -183,6 +183,12 @@ void ESP32EVSEComponent::setup() {
   });
 }
 
+void ESP32EVSEComponent::add_ready_trigger(ESP32EVSEReadyTrigger *trigger) {
+  if (trigger == nullptr)
+    return;
+  this->ready_triggers_.push_back(trigger);
+}
+
 // Process incoming UART bytes and drive the command queue.  This keeps the ESPHome
 // scheduler responsive even while waiting for EVSE acknowledgements.
 void ESP32EVSEComponent::loop() {
@@ -705,6 +711,14 @@ void ESP32EVSEComponent::process_line_(const std::string &line) {
   }
   if (line == "ERROR") {
     this->handle_ack_(false);
+    return;
+  }
+  if (line == "RDY") {
+    ESP_LOGI(TAG, "EVSE ready to accept commands");
+    for (auto *trigger : this->ready_triggers_) {
+      if (trigger != nullptr)
+        trigger->notify();
+    }
     return;
   }
   if (const char *value = value_after_prefix(line, "+STATE")) {

--- a/components/esp32evse/esp32evse.h
+++ b/components/esp32evse/esp32evse.h
@@ -21,6 +21,7 @@
 #include <limits>
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace esphome {
 namespace esp32evse {
@@ -35,6 +36,7 @@ class ESP32EVSEAuthorizeButton;
 class ESP32EVSEPendingAuthorizationBinarySensor;
 class ESP32EVSEWifiConnectedBinarySensor;
 class ESP32EVSEChargingLimitReachedBinarySensor;
+class ESP32EVSEReadyTrigger;
 
 template<typename... Ts>
 class ESP32EVSEManagedSubscriptionAction;
@@ -205,6 +207,8 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   void request_default_under_power_limit_update();
   void request_pending_authorization_update();
   void request_charging_limit_reached_update();
+
+  void add_ready_trigger(ESP32EVSEReadyTrigger *trigger);
 
   // Writers mirror user initiated actions back to the EVSE controller.
   void write_enable_state(bool enabled);
@@ -412,6 +416,7 @@ class ESP32EVSEComponent : public uart::UARTDevice, public PollingComponent {
   // Per-slot timestamps that power the freshness tracker.  A ``0`` entry means
   // the slot has never received a response and should not suppress polling yet.
   std::array<uint32_t, static_cast<size_t>(FreshnessSlot::SLOT_COUNT)> last_response_millis_{};
+  std::vector<ESP32EVSEReadyTrigger *> ready_triggers_;
 };
 
 // Lightweight wrappers for the ESPHome entity classes.  They forward state
@@ -476,6 +481,11 @@ class ESP32EVSEWifiConnectedBinarySensor : public binary_sensor::BinarySensor,
 class ESP32EVSEChargingLimitReachedBinarySensor
     : public binary_sensor::BinarySensor,
       public Parented<ESP32EVSEComponent> {};
+
+class ESP32EVSEReadyTrigger : public Trigger<>, public Parented<ESP32EVSEComponent> {
+ public:
+  void notify() { this->trigger(); }
+};
 
 template<typename... Ts>
 class ESP32EVSEManagedSubscriptionAction : public Action<Ts...>, public Parented<ESP32EVSEComponent> {


### PR DESCRIPTION
## Summary
- update the ready trigger schema and registration logic to support IDs and both register_trigger and register_action entry points
- build the esp32evse.on_ready automations through a shared finalizer so configured actions run when RDY is received

## Testing
- python -m compileall components/esp32evse

------
https://chatgpt.com/codex/tasks/task_e_68e026eea8c0832781fdf8a7de3cc556