### PR TITLE
Use LF line endings for EVSE command writes

### DIFF
--- a/components/esp32evse/esp32evse.cpp
+++ b/components/esp32evse/esp32evse.cpp
@@ -1010,7 +1010,7 @@ void ESP32EVSEComponent::process_next_command_() {
 
   ESP_LOGV(TAG, "Sending command: %s", front.command.c_str());
   this->write_str(front.command.c_str());
-  this->write_str("\r\n");
+  this->write_str("\n");
   front.start_time = millis();
   front.sent = true;
 }


### PR DESCRIPTION
## Summary
- update the UART command transmission to terminate messages with LF only, matching the EVSE expectation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e035e8179c8327b36e6943c7a244aa