### PR TITLE
Ensure binary sensors trigger on initial state

### DIFF
--- a/components/esp32evse/binary_sensor.py
+++ b/components/esp32evse/binary_sensor.py
@@ -16,6 +16,7 @@ from esphome.const import (
     DEVICE_CLASS_CONNECTIVITY,
     DEVICE_CLASS_PROBLEM,
     ENTITY_CATEGORY_DIAGNOSTIC,
+    CONF_TRIGGER_ON_INITIAL_STATE,
 )
 
 from . import CONF_ESP32EVSE_ID, ESP32EVSEComponent, esp32evse_ns
@@ -69,6 +70,15 @@ CONF_RCM_TRIGGERED = "rcm_triggered_fault"
 CONF_RCM_SELF_TEST_FAULT = "rcm_self_test_fault"
 CONF_TEMPERATURE_HIGH_FAULT = "temperature_high_fault"
 CONF_TEMPERATURE_FAULT = "temperature_fault"
+
+
+def _with_default_trigger(config: dict) -> dict:
+    """Ensure binary sensors trigger automations on their initial state."""
+
+    if CONF_TRIGGER_ON_INITIAL_STATE in config:
+        return config
+    # Copy to avoid mutating the validated configuration that ESPHome stores.
+    return {**config, CONF_TRIGGER_ON_INITIAL_STATE: True}
 
 
 CONFIG_SCHEMA = cv.All(
@@ -164,19 +174,25 @@ async def to_code(config):
     if pending_config := config.get(CONF_PENDING_AUTHORIZATION):
         # The pending-authorization flag is updated whenever the EVSE expects a
         # user action (such as tapping an RFID card), so we forward its state.
-        sens = await binary_sensor.new_binary_sensor(pending_config)
+        sens = await binary_sensor.new_binary_sensor(
+            _with_default_trigger(pending_config)
+        )
         await cg.register_parented(sens, config[CONF_ESP32EVSE_ID])
         cg.add(parent.set_pending_authorization_binary_sensor(sens))
     if wifi_config := config.get(CONF_WIFI_CONNECTED):
         # Track Wi-Fi connectivity so operators can detect when the charger
         # falls offline without looking at the controller's web UI.
-        sens = await binary_sensor.new_binary_sensor(wifi_config)
+        sens = await binary_sensor.new_binary_sensor(
+            _with_default_trigger(wifi_config)
+        )
         await cg.register_parented(sens, config[CONF_ESP32EVSE_ID])
         cg.add(parent.set_wifi_connected_binary_sensor(sens))
     if limit_config := config.get(CONF_CHARGING_LIMIT_REACHED):
         # Surface the flag that signals when the EVSE stopped charging because a
         # configured limit (time/energy/under-power) has been reached.
-        sens = await binary_sensor.new_binary_sensor(limit_config)
+        sens = await binary_sensor.new_binary_sensor(
+            _with_default_trigger(limit_config)
+        )
         await cg.register_parented(sens, config[CONF_ESP32EVSE_ID])
         cg.add(parent.set_charging_limit_reached_binary_sensor(sens))
     for key, setter in (
@@ -190,6 +206,8 @@ async def to_code(config):
         (CONF_TEMPERATURE_FAULT, parent.set_temperature_fault_binary_sensor),
     ):
         if sensor_config := config.get(key):
-            sens = await binary_sensor.new_binary_sensor(sensor_config)
+            sens = await binary_sensor.new_binary_sensor(
+                _with_default_trigger(sensor_config)
+            )
             await cg.register_parented(sens, config[CONF_ESP32EVSE_ID])
             cg.add(setter(sens))


### PR DESCRIPTION
## Summary
- ensure every ESP32 EVSE binary sensor defaults to `trigger_on_initial_state`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e03e3dce4c832792119d2c8016de77