### PR TITLE
esp32evse: unify subscription period handling and ensure templating receives primitive values

### DIFF
--- a/components/esp32evse/__init__.py
+++ b/components/esp32evse/__init__.py
@@ -254,14 +254,13 @@ def _register_subscription_action(name: str, command: str) -> None:
         cg.add(var.set_command(_command))
         period_config = config[CONF_PERIOD]
         if isinstance(period_config, str):
-            period = cg.uint32(0)
+            period_config = 0
         elif isinstance(period_config, cv.TimePeriod):
             if getattr(period_config, "is_never", False):
-                period = cg.uint32(0)
+                period_config = 0
             else:
-                period = cg.uint32(period_config.total_milliseconds)
-        else:
-            period = await cg.templatable(period_config, args, cg.uint32)
+                period_config = period_config.total_milliseconds
+        period = await cg.templatable(period_config, args, cg.uint32)
         cg.add(var.set_period(period))
         return var
 


### PR DESCRIPTION
### Motivation

- Fix inconsistent handling of the `period` field for subscription actions so templating is always applied to a primitive value and `0` is used for string/never time periods.

### Description

- Consolidate period processing in `subscription_action_to_code` by converting string and `cv.TimePeriod` (`is_never`) cases to `0` and `cv.TimePeriod` durations to milliseconds, storing the result in `period_config` before templating. 
- Replace multiple early `cg.uint32(...)` constructions with a single `await cg.templatable(period_config, args, cg.uint32)` call and then `var.set_period(period)`.

### Testing

- Ran the project's unit tests and type checks against the modified code and they all passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d778061fa88327b381eaa1881e7d7d)